### PR TITLE
Implement test cases for generate.py

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1,0 +1,58 @@
+# Import the necessary libraries
+import os
+
+# Directories to ignore 
+ignore_directory_list = [".git", ".github", ".pytest_cache", "__pycache__"]
+# Files to ignore
+ignore_files_list = [
+    ".gitignore", 
+    "pyproject.toml",
+     ".DS_Store", 
+     ".markdownlint.json", 
+     "README.md", 
+     "gatorgrader.yml", 
+     "build.gradle",
+     "__init__.py",
+     "gatorgrade.yml"]
+
+# Final paths to write to the gatorgrade.yml file
+final_paths = []
+
+for dirpath, dirnames, filenames in os.walk("."):
+    """Generate the file names in a directory tree by walking the file tree top-down"""
+
+    # Remove directories from directory lists based on ignore_directory_list
+    for name in ignore_directory_list:
+        if name in dirnames:
+            dirnames.remove(name)
+
+    # Remove files from files lists based on ignore_files_list
+    for name in ignore_files_list:
+        if name in filenames:
+            filenames.remove(name)
+
+    # Print path to all filenames
+    for filename in filenames:
+        # Join the directory path with the filename
+        # print(os.path.join(dirpath, filename))
+        final_paths.append(os.path.join(dirpath, filename))
+
+    
+# Create a new YAML file 
+gatorgrader_file = open("gatorgrade.yml", "w")
+
+# Write to the file the name of the paths
+for path in final_paths:
+    # Remove the "." and "/" from path names
+    without_dot = path.strip("./")
+    # Write to the gatorgrade.yml in the format professor wrote on the board
+    gatorgrader_file.write(f"{without_dot}:\n\t--description:\n\tcheck: MatchFileFragment\n\toptions:\n\t\tcount:\n\t\tfragment: TODO\n\t\texact: {True}")
+    # gatorgrader_file.write(f"{without_dot}:\n")
+
+    # Space between file paths in the gatorgrade.yml file
+    gatorgrader_file.write("\n")
+    gatorgrader_file.write("\n")
+
+# Close the file
+gatorgrader_file.close()
+

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -13,7 +13,7 @@ def str_representer(dumper, data):
 
 def test_generate_should_create_gatorgrade_yml_file(tmp_path, capsys):
     """Check if the generate.py creates a gatorgrade.yml file in the root directory after it's run"""
-    
+
     # Given a lab directory contains all of the files and folders that user inputted when calling generate.py
     root_directory = tmp_path / "Lab-03"
     root_directory.mkdir()
@@ -47,7 +47,9 @@ def test_generate_should_create_gatorgrade_yml_file(tmp_path, capsys):
     assert file_path.is_file()
 
 
-def test_generated_gatorgrade_yml_file_should_contain_correct_paths_when_successfully_ran(tmp_path, capsys):
+def test_generated_gatorgrade_yml_file_should_contain_correct_paths_when_successfully_ran(
+    tmp_path, capsys
+):
     """Check if gatorgrade.yml contains correct paths when successfully created"""
 
     # Given an assignment directory that contains all of the folders and files that user inputted when calling generate.py
@@ -78,7 +80,7 @@ def test_generated_gatorgrade_yml_file_should_contain_correct_paths_when_success
     output_directory.mkdir()
     output_file = output_directory / "output.txt"
     output_file.write_text("Test output")
-    
+
     tests_directory = root_directory / "tests"
     tests_directory.mkdir()
     test_file = tests_directory / "test_file.py"
@@ -94,7 +96,6 @@ def test_generated_gatorgrade_yml_file_should_contain_correct_paths_when_success
 
     pyproject_file = root_directory / "pyproject.toml"
     pyproject_file.write_text("[tool.poetry]")
-
 
     # When we call the modularized version of "generate.py" with two arguments
 
@@ -116,7 +117,7 @@ def test_generated_gatorgrade_yml_file_should_contain_correct_paths_when_success
             ]
         },
         {
-             "src/output/output.txt": [
+            "src/output/output.txt": [
                 {
                     "description": "Complete all TODOs",
                     "check": "MatchFileFragment",
@@ -159,13 +160,17 @@ def test_generated_gatorgrade_yml_file_should_contain_correct_paths_when_success
                     "options": {"fragment": "TODO", "count": 0, "exact": True},
                 }
             ]
-        }
+        },
     ]
 
     yaml.add_representer(str, str_representer)
 
     gatorgrade_yml = root_directory / "gatorgrade.yml"
-    gatorgrade_yml.write_text(yaml.dump_all((setup_dict, files_list), default_flow_style=False, sort_keys=False))
+    gatorgrade_yml.write_text(
+        yaml.dump_all(
+            (setup_dict, files_list), default_flow_style=False, sort_keys=False
+        )
+    )
 
     file = gatorgrade_yml.open()
     file_text = file.read()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,45 @@
+# Import needed libraries
+import pytest
+from pathlib import Path
+
+
+def test_generate_should_create_gatorgrade_yml_file(tmp_path, capsys):
+    """Check if the generate.py creates a gatorgrade.yml file in the root directory after it's run"""
+    
+    # Given a lab directory contains all of the files and folders that user inputted when calling generate.py
+    root_directory = tmp_path / "lab3"
+    root_directory.mkdir()
+
+    src_directory = root_directory / "src"
+    src_directory.mkdir()
+
+    readme_file = root_directory / "README.md"
+    readme_file.write_text("# Lab 3")
+
+    github_directory = root_directory / ".github"
+    github_directory.mkdir()
+
+    config_directory = root_directory / "config"
+    config_directory.mkdir()
+
+    writing_directory = root_directory / "writing"
+    writing_directory.mkdir()
+    reflection_file = writing_directory / "reflection.md"
+    reflection_file.mkdir()
+
+    # gatorgrade_yml = root_directory / "gatorgrade.yml"
+    # gatorgrade_yml.write_text("Setup: ")
+
+    with capsys.disabled():
+        print(root_directory)
+
+    # When we call the modularized version of "generate.py" with two arguments
+
+    # generate_config(["src", "README.md"], root_directory)
+
+    # Then "gatrograde.yml" is generated in the root directory
+    file_path = Path(root_directory / "gatorgrade.yml")
+    assert file_path.is_file()
+
+
+

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,20 +1,22 @@
+"""This module tests the generate.py functionality"""
+
 # Import needed libraries
-import pytest
 from pathlib import Path
 import yaml
 
-# PyYAML function needed for creating a mock "gatorgrade.yml" file
+
 def str_representer(dumper, data):
+    """PyYAML function needed for creating a mock "gatorgrade.yml" file"""
     if data.count("\n") > 0:
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
 
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
 
-def test_generate_should_create_gatorgrade_yml_file(tmp_path, capsys):
-    """Check if the generate.py creates a gatorgrade.yml file in the root directory after it's run"""
+def test_generate_should_create_gatorgrade_yml_file(tmp_path):
+    """Check if generate.py creates a gatorgrade.yml file in the root directory after it's run"""
 
-    # Given a lab directory contains all of the files and folders that user inputted when calling generate.py
+    # Given a directory contains all the files and folders user inputted when calling generate.py
     root_directory = tmp_path / "Lab-03"
     root_directory.mkdir()
 
@@ -48,11 +50,12 @@ def test_generate_should_create_gatorgrade_yml_file(tmp_path, capsys):
 
 
 def test_generated_gatorgrade_yml_file_should_contain_correct_paths_when_successfully_ran(
-    tmp_path, capsys
+    tmp_path,
 ):
     """Check if gatorgrade.yml contains correct paths when successfully created"""
 
-    # Given an assignment directory that contains all of the folders and files that user inputted when calling generate.py
+    # Given an assignment directory that contains all of the folders
+    # and files that user inputted when calling generate.py
     root_directory = tmp_path / "Practical-01"
     root_directory.mkdir()
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,13 +1,21 @@
 # Import needed libraries
 import pytest
 from pathlib import Path
+import yaml
+
+# PyYAML function needed for creating a mock "gatorgrade.yml" file
+def str_representer(dumper, data):
+    if data.count("\n") > 0:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
 
 def test_generate_should_create_gatorgrade_yml_file(tmp_path, capsys):
     """Check if the generate.py creates a gatorgrade.yml file in the root directory after it's run"""
     
     # Given a lab directory contains all of the files and folders that user inputted when calling generate.py
-    root_directory = tmp_path / "lab3"
+    root_directory = tmp_path / "Lab-03"
     root_directory.mkdir()
 
     src_directory = root_directory / "src"
@@ -25,13 +33,10 @@ def test_generate_should_create_gatorgrade_yml_file(tmp_path, capsys):
     writing_directory = root_directory / "writing"
     writing_directory.mkdir()
     reflection_file = writing_directory / "reflection.md"
-    reflection_file.mkdir()
+    reflection_file.write_text("# Reflection on Lab 03")
 
-    # gatorgrade_yml = root_directory / "gatorgrade.yml"
-    # gatorgrade_yml.write_text("Setup: ")
-
-    with capsys.disabled():
-        print(root_directory)
+    gatorgrade_yml = root_directory / "gatorgrade.yml"
+    gatorgrade_yml.write_text("Setup: ")
 
     # When we call the modularized version of "generate.py" with two arguments
 
@@ -42,4 +47,133 @@ def test_generate_should_create_gatorgrade_yml_file(tmp_path, capsys):
     assert file_path.is_file()
 
 
+def test_generated_gatorgrade_yml_file_should_contain_correct_paths_when_successfully_ran(tmp_path, capsys):
+    """Check if gatorgrade.yml contains correct paths when successfully created"""
 
+    # Given an assignment directory that contains all of the folders and files that user inputted when calling generate.py
+    root_directory = tmp_path / "Practical-01"
+    root_directory.mkdir()
+
+    github_directory = root_directory / ".github"
+    github_directory.mkdir()
+
+    src_directory = root_directory / "src"
+    src_directory.mkdir()
+
+    main_py = src_directory / "main.py"
+    main_py.write_text("import sys")
+
+    test_file_1 = src_directory / "test_file_1.py"
+    test_file_1.write_text("import sys")
+
+    test_file_2 = src_directory / "test_file_2.py"
+    test_file_2.write_text("import sys")
+
+    input_directory = src_directory / "input"
+    input_directory.mkdir()
+    input_file = input_directory / "input.txt"
+    input_file.write_text("Test input")
+
+    output_directory = src_directory / "output"
+    output_directory.mkdir()
+    output_file = output_directory / "output.txt"
+    output_file.write_text("Test output")
+    
+    tests_directory = root_directory / "tests"
+    tests_directory.mkdir()
+    test_file = tests_directory / "test_file.py"
+    test_file.write_text("import pytest")
+
+    writing_directory = root_directory / "writing"
+    writing_directory.mkdir()
+    reflection_file = writing_directory / "reflection.md"
+    reflection_file.write_text("# Reflection on Practical 01")
+
+    readme_file = root_directory / "README.md"
+    readme_file.write_text("# Practical 01")
+
+    pyproject_file = root_directory / "pyproject.toml"
+    pyproject_file.write_text("[tool.poetry]")
+
+
+    # When we call the modularized version of "generate.py" with two arguments
+
+    # generate_config(["src", "README.md"], root_directory)
+
+    # Generate a mock "gatorgrade.yml" for testing purposes
+    setup_dict = {
+        "setup": "# add setup commands here\n",
+    }
+
+    files_list = [
+        {
+            "src/input/input.txt": [
+                {
+                    "description": "Complete all TODOs",
+                    "check": "MatchFileFragment",
+                    "options": {"fragment": "TODO", "count": 0, "exact": True},
+                }
+            ]
+        },
+        {
+             "src/output/output.txt": [
+                {
+                    "description": "Complete all TODOs",
+                    "check": "MatchFileFragment",
+                    "options": {"fragment": "TODO", "count": 0, "exact": True},
+                }
+            ]
+        },
+        {
+            "src/main.py": [
+                {
+                    "description": "Complete all TODOs",
+                    "check": "MatchFileFragment",
+                    "options": {"fragment": "TODO", "count": 0, "exact": True},
+                }
+            ]
+        },
+        {
+            "src/test_file_1.py": [
+                {
+                    "description": "Complete all TODOs",
+                    "check": "MatchFileFragment",
+                    "options": {"fragment": "TODO", "count": 0, "exact": True},
+                }
+            ]
+        },
+        {
+            "src/test_file_2.py": [
+                {
+                    "description": "Complete all TODOs",
+                    "check": "MatchFileFragment",
+                    "options": {"fragment": "TODO", "count": 0, "exact": True},
+                }
+            ]
+        },
+        {
+            "README.md": [
+                {
+                    "description": "Complete all TODOs",
+                    "check": "MatchFileFragment",
+                    "options": {"fragment": "TODO", "count": 0, "exact": True},
+                }
+            ]
+        }
+    ]
+
+    yaml.add_representer(str, str_representer)
+
+    gatorgrade_yml = root_directory / "gatorgrade.yml"
+    gatorgrade_yml.write_text(yaml.dump_all((setup_dict, files_list), default_flow_style=False, sort_keys=False))
+
+    file = gatorgrade_yml.open()
+    file_text = file.read()
+
+    # Then the "gatorgrade.yml" contains correct paths to user inputted directories and files
+    assert "- src/input/input.txt:" in file_text
+    assert "- src/output/output.txt:" in file_text
+    assert "- src/main.py:" in file_text
+    assert "- src/test_file_1.py:" in file_text
+    assert "- src/test_file_2.py:" in file_text
+    assert "- README.md:" in file_text


### PR DESCRIPTION
<!-- Replace the title below -->
# Test cases for generate.py

## Description

<!-- Write a description of the proposed changes -->
<!-- Remember to check the reminders! -->
This PR implements unit test cases for generate.py to increase our confidence in the correctness of generate.py functionality, improving the sustainability of our Software Engineering Project. Specifically, the test cases are for: 

1. Successful generation of "gatorgrade.yml" in the root directory.
2. Correct path generation in the "gatorgrade.yml" file when all the files and directories exist that the user has provided.
3. Warning case where some of the user-provided files exist but some of the files don't exist. In this case, "gatorgrade.yml" should still be generated with the existing file paths and output a warning message to the console to warn the user about the missing files and directories.
4. Failure case where none of the user-inputted files and directories exist in the root directory. In this case, "gatorgrade.yml" should not be generated and there should be a failure message in the console to notify the user.

### Additional comment
The test cases for warning and failure still need to be implemented. I'm thinking about implementing those cases after we've added the feature for exception handling in our generate.py module. Also, the test cases for successful generation and correct path generation do not call the `generate_config()` method since it's not implemented yet. In the future, I will modify these test cases to use the function after we've done with our generate.py module, which should be relatively easy: I just need to uncomment and delete a few lines. 

Finally, there's one issue with Pylint in GitHub Actions. It says that I have too many local variables in my test function which are needed to configure a temporary directory to simulate an actual assignment directory. Specifically, Pylint says that I have 22 variables when I'm supposed to have 15 maximum. This is the only issue I have with GitHub Actions to receive a green checkmark. I'm wondering how I should resolve this issue? Is it possible to change the settings for Pylint to change the maximum number of local variables a function can have?

Please ignore the "generate.py" file below when reviewing this PR. I created this file three weeks ago as a prototype and somehow it ended up showing up here in this PR. This is NOT the final "generate.py".

## Linked Issues

<!-- Fill in which issue number this PR closes, if there is none, just remove this section! -->
closes: #51 

## Type of Change

<!-- Fill in the brackets with an `x` next to all types that apply to the proposed changes -->
- [x] Feature
- [ ] Bug fix
- [ ] Documentation

## Contributors

<!-- Add your GitHub username below and the GitHub usernames of all other contributors to the proposed changes -->
- @Ochirsaikhan 

## Reminder

 - All GitHub Actions should be in a passing state before any pull request is merged.
 - All PRs must be reviewed by at least one team member and one member of the Integration team!
 - Any issues this PR closes are tagged in the description!
