### PR TITLE
Hotfix/current dir relation

### DIFF
--- a/gatorgrade/generate/generate.py
+++ b/gatorgrade/generate/generate.py
@@ -128,6 +128,3 @@ def generate_config(target_path_list: List[str], search_root: str = "."):
     """Generate config by creating targeted paths in a list of strings, then create a YAML file."""
     targeted_paths = create_targeted_paths_list(target_path_list, search_root)
     write_yaml_of_paths_list(targeted_paths, search_root)
-
-
-generate_config(["index.md"], "../docs")

--- a/gatorgrade/generate/generate.py
+++ b/gatorgrade/generate/generate.py
@@ -15,7 +15,8 @@ def input_correct(initial_path_list: List[str]) -> Dict:
     # Unify the ending format to avoid different users' different input
     corrected_path = []
     for path in initial_path_list:
-
+        # Make sure the target path starts from the current directory
+        path = f".{os.path.sep}" + path
         if path.endswith(os.path.sep) is False:
             path += os.path.sep
         corrected_path.append(path)

--- a/gatorgrade/generate/generate.py
+++ b/gatorgrade/generate/generate.py
@@ -15,6 +15,8 @@ def input_correct(initial_path_list: List[str]) -> Dict:
     # Unify the ending format to avoid different users' different input
     corrected_path = []
     for path in initial_path_list:
+        # Make sure the target path gets started in the current directory
+        path = "./" + path
         if path.endswith("/") is False:
             path += "/"
         corrected_path.append(path)
@@ -49,6 +51,7 @@ def create_targeted_paths_list(
             if filename.startswith("__") or filename.startswith("."):
                 continue
             # Combine the path with file name to get a complete path
+            # align format with target path
             complete_actual_path = os.path.join(dirpath, filename) + "/"
             for target in corrected_paths:
                 if target in complete_actual_path:

--- a/gatorgrade/generate/generate.py
+++ b/gatorgrade/generate/generate.py
@@ -9,14 +9,19 @@ WARNING = "\033[93m"
 FAIL = "\033[91m"
 
 
-def input_correct(initial_path_list: List[str]) -> Dict:
+def input_correct(initial_path_list: List[str], run_path: str) -> Dict:
     """Correct user-written paths."""
     # Recognize the paths users provide are the concise versions.
     # Unify the ending format to avoid different users' different input
     corrected_path = []
+    # Run_path unify
+    if run_path.endswith(os.path.sep) is False:
+        run_path += os.path.sep
     for path in initial_path_list:
-        # Make sure the target path starts from the current directory
-        path = f".{os.path.sep}" + path
+        # Combine the running path with the target path
+        # To make sure the target path starts from the running directory
+        path = run_path + path
+        # Treat the last unit of the path as a concise name unit
         if path.endswith(os.path.sep) is False:
             path += os.path.sep
         corrected_path.append(path)
@@ -29,7 +34,7 @@ def create_targeted_paths_list(
 ) -> List[str]:
     """Generate a list of targeted paths by walking the paths."""
     targeted_paths = []
-    corrected_paths = input_correct(target_path_list)
+    corrected_paths = input_correct(target_path_list, relative_run_path)
     # Go through the root repo, the sub dictionaries and files
     # The os.walk will only scan the paths
     # So the empty folders containing nothing won't be gone through
@@ -51,7 +56,6 @@ def create_targeted_paths_list(
             if filename.startswith("__") or filename.startswith("."):
                 continue
             # Combine the path with file name to get a complete path
-
             complete_actual_path = os.path.join(dirpath, filename) + os.path.sep
             for target in corrected_paths:
                 if target in complete_actual_path:
@@ -124,3 +128,6 @@ def generate_config(target_path_list: List[str], search_root: str = "."):
     """Generate config by creating targeted paths in a list of strings, then create a YAML file."""
     targeted_paths = create_targeted_paths_list(target_path_list, search_root)
     write_yaml_of_paths_list(targeted_paths, search_root)
+
+
+generate_config(["index.md"], "../docs")

--- a/tests/test_generate_success.py
+++ b/tests/test_generate_success.py
@@ -2,7 +2,6 @@
 """Test the generate_config function in a perfect situation."""
 import os
 import pytest
-from pathlib import Path
 from gatorgrade.generate.generate import generate_config
 
 

--- a/tests/test_generate_success.py
+++ b/tests/test_generate_success.py
@@ -2,6 +2,7 @@
 """Test the generate_config function in a perfect situation."""
 import os
 import pytest
+from pathlib import Path
 from gatorgrade.generate.generate import generate_config
 
 
@@ -26,7 +27,7 @@ def setup_files(tmp_path):
 def test_generate_config_create_gatorgrade_yml(testing_dir):
     """Test to see that gatorgrade_yml file exist in file structure"""
     # When generate_config is called
-    generate_config(["src"], testing_dir)
+    generate_config(["src"], str(testing_dir))
     # Then gatorgrade.yml is created
     gatorgrade_yml = testing_dir / "gatorgrade.yml"
     assert gatorgrade_yml.is_file()
@@ -35,7 +36,7 @@ def test_generate_config_create_gatorgrade_yml(testing_dir):
 def test_generate_config_creates_gatorgrade_yml_with_dir_in_user_input(testing_dir):
     """Test to see if input matches directory"""
     # When generate_config is called
-    generate_config(["src"], testing_dir)
+    generate_config(["src"], str(testing_dir))
     # Then gatorgrade.yml is created
     gatorgrade_yml = testing_dir / "gatorgrade.yml"
     assert os.path.normpath("src/test.py") in gatorgrade_yml.open().read()
@@ -46,7 +47,7 @@ def test_generate_config_creates_gatorgrade_yml_without_dir_not_in_user_input(
 ):
     """Test to see if input does not match directory"""
     # When generate_config is called
-    generate_config(["writing"], testing_dir)
+    generate_config(["writing"], str(testing_dir))
     # Then gatorgrade.yml is created
     gatorgrade_yml = testing_dir / "gatorgrade.yml"
     assert os.path.normpath("src/test.py") not in gatorgrade_yml.open().read()
@@ -56,7 +57,7 @@ def test_generate_config_creates_gatorgrade_yml_without_dir_not_in_user_input(
 def test_generate_success_message(capsys, testing_dir):
     """Test to see that there is a success message"""
     # When generate_config is called
-    generate_config(["src"], testing_dir)
+    generate_config(["src"], str(testing_dir))
     out, _ = capsys.readouterr()
     # Then a success message is printed
     assert "SUCCESS" in out


### PR DESCRIPTION
<!-- TODO: Replace the title below -->
Hotfix - Correct the Target Scan Range

## Description

The target was not correctly connected to the current directory. So that if you provided one filename, the tool would have found it not only in the current directory but also in the deeper ones, which is unacceptable. This PR fixed this bug.
OK, I have to admit that right now this hotfix is not as hot as I thought. The test didn't pass and I don't know if the problem is from the implementation or the test.
## Linked Issues

<!-- Fill in which issue number this PR closes, if there is none, just remove this section! -->
closes: #00

## Type of Change

<!-- TODO: Fill in the brackets with an `x` next to all types that apply to the proposed changes -->
- [x] Feature
- [x] Bug fix
- [ ] Documentation

## Contributors

<!-- TODO: Add your GitHub username below and the GitHub usernames of all other contributors to the proposed changes -->
- @Yanqiao4396 

## Reminder

 - All GitHub Actions should be in a passing state before any pull request is merged.
 - All PRs must be reviewed by at least one team member and one member of the Integration team!
 - Any issues this PR closes are tagged in the description!
