### PR TITLE
Hotfix: fix windows setup shell

### DIFF
--- a/gatorgrade/input/set_up_shell.py
+++ b/gatorgrade/input/set_up_shell.py
@@ -1,5 +1,5 @@
 """Set-up the shell commands."""
-import os
+import subprocess
 import sys
 
 
@@ -12,17 +12,16 @@ def run_setup(front_matter):
 
     """
     # If setup exists in the front matter
-    if front_matter.get("setup") is not None:
+    setup = front_matter.get("setup")
+    if setup:
         print("Running set up commands...")
-        for line in front_matter["setup"].splitlines():
+        for line in setup.splitlines():
             # Trims the white space
             command = line.strip()
             # Executes the command
-            exit_status = os.system(command)
-            # Extracts the exit code value from the exit status.
-            exit_code = os.waitstatus_to_exitcode(exit_status)
+            proc = subprocess.run(command, shell=True, check=False, timeout=300)
             # If the exit code tells it was unsuccessful and did not return 0
-            if exit_code != 0:
+            if proc.returncode != 0:
                 print(
                     f'The set up command "{command}" failed.\
                 Exiting GatorGrade.',
@@ -31,3 +30,4 @@ def run_setup(front_matter):
                 # If a set up command failed, exit the execution
                 # because environment was not set up correctly.
                 sys.exit(1)
+        print("Finished!\n")

--- a/gatorgrade/input/set_up_shell.py
+++ b/gatorgrade/input/set_up_shell.py
@@ -20,7 +20,7 @@ def run_setup(front_matter):
             # Executes the command
             exit_status = os.system(command)
             # Extracts the exit code value from the exit status.
-            exit_code = os.WEXITSTATUS(exit_status)
+            exit_code = os.waitstatus_to_exitcode(exit_status)
             # If the exit code tells it was unsuccessful and did not return 0
             if exit_code != 0:
                 print(


### PR DESCRIPTION
# Fix Setup Commands on Windows

## Description

The setup commands would fail on Windows due to the non-existence of `os.WEXITSTATUS`, which is not available on Windows.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation

## Contributors

- @Michionlion 

## Reminder

 - All GitHub Actions should be in a passing state before any pull request is merged.
 - All PRs must be reviewed by at least one team member and one member of the Integration team!
 - Any issues this PR closes are tagged in the description!
