### PR TITLE
Hotfix: output displays only a single failure

### DIFF
--- a/gatorgrade/output/output_functions.py
+++ b/gatorgrade/output/output_functions.py
@@ -96,8 +96,7 @@ def output_failed_checks(failed_checks):
         description = check[2]
         # Use colorama to print and style "X"
         print(f"{color.Fore.RED}\u2718  {color.Style.RESET_ALL}{requirement}")
-        print(f"    {color.Fore.YELLOW}\u2192  {description}")
-        return bool
+        print(f"    {color.Fore.YELLOW}\u2192  {description}{color.Style.RESET_ALL}")
 
 
 def run_and_display_command_checks(commands):

--- a/gatorgrade/output/output_percentage_printing.py
+++ b/gatorgrade/output/output_percentage_printing.py
@@ -1,5 +1,5 @@
 """Output with the percentage of checks that the student has met requirments."""
-from colorama import Fore
+import colorama as color
 
 
 def print_percentage(results):
@@ -13,11 +13,14 @@ def print_percentage(results):
     percent = math * 100  # get the percent to non decimal.
     if percent == 100.0:
         return (
-            f"{Fore.GREEN}|=====================================|\n"
+            color.Fore.GREEN
+            + "|=====================================|\n"
             + f"|Passing all GatorGrader Checks {percent}%|\n"
             + "|=====================================|"
+            + color.Style.RESET_ALL
         )
 
     return (
-        f"\n{Fore.RED}Passing {len(true_list)}/{len(results)}, Grade is {percent}%.\n"
+        f"\n{color.Fore.RED}Passing {len(true_list)}/{len(results)}, "
+        f"Grade is {percent}%.\n{color.Style.RESET_ALL}"
     )

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -10,7 +10,7 @@ color.init()
 @pytest.fixture()
 def test_output_shows_green(capsys):
     """Test for ouput of a passed check will show green check."""
-    output_functions.output_passed_checks(passed_checks=("Remove All TODOs", True, ""))
+    output_functions.output_passed_checks([("Remove All TODOs", True, "")])
     out, err = capsys.readouterr()
     expected_output = f"{color.Fore.GREEN}\u2714"
 
@@ -22,7 +22,7 @@ def test_output_shows_green(capsys):
 def test_output_shows_red(capsys):
     """Test for output of failed check to show red color using Colorama."""
     output_functions.output_failed_checks(
-        failed_checks=("Remove all TODOs", False, "3 TODOs found in example.py")
+        [("Remove all TODOs", False, "3 TODOs found in example.py")]
     )
     out, err = capsys.readouterr()
 
@@ -35,7 +35,7 @@ def test_output_shows_red(capsys):
 def test_output_shows_yellow(capsys):
     """Testing the failed check will show a yellow message in output."""
     output_functions.output_failed_checks(
-        failed_checks=("Remove all TODOs", False, "3 TODOs found in example.py")
+        [("Remove all TODOs", False, "3 TODOs found in example.py")]
     )
     out, err = capsys.readouterr()
     expected_output = f"{color.Fore.YELLOW}\u2192"
@@ -47,10 +47,10 @@ def test_output_shows_yellow(capsys):
 def test_descrition_in_fail_message(capsys):
     """Testing the failed check will show diagnostic yellow message in output."""
     output_functions.output_failed_checks(
-        failed_checks=("Implement this with an if.", False, "No if statements found")
+        [("Implement this with an if.", False, "No if statements found")]
     )
     out, err = capsys.readouterr()
-    expected_output = "\x1b[31m✘  \x1b[0mI\n    \x1b[33m→  p\n"
+    expected_output = f"{color.Fore.YELLOW}→  No if statements found"
     actual_output = out
     assert expected_output in actual_output
     assert "" in err
@@ -59,7 +59,7 @@ def test_descrition_in_fail_message(capsys):
 def test_false_result_returns_x(capsys):
     """Test will result a X mark in the output for the failed check."""
     output_functions.output_failed_checks(
-        failed_checks=("Implement this with an if.", False, "No if statements found")
+        [("Implement this with an if.", False, "No if statements found")]
     )
     out, err = capsys.readouterr()
     unicode_x = "\u2718"


### PR DESCRIPTION
# Fix single failure only display

## Description

GatorGrade will only display a single failure (and skip displaying anything else) in all cases due to an extraneous `return` statement. This PR removes that return statement, and fixes the resulting test issues (which was likely the reason the `return` was first added).

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation

## Contributors

- @Michionlion 

## Reminder

 - All GitHub Actions should be in a passing state before any pull request is merged.
 - All PRs must be reviewed by at least one team member and one member of the Integration team!
 - Any issues this PR closes are tagged in the description!
