### PR TITLE
Switch to using Typer styling, printing, and exiting

### DIFF
--- a/gatorgrade/generate/generate.py
+++ b/gatorgrade/generate/generate.py
@@ -2,11 +2,7 @@
 import os
 from typing import List, Dict
 import yaml
-
-# Define colors for terminal output
-OKGREEN = "\033[92m"
-WARNING = "\033[93m"
-FAIL = "\033[91m"
+import typer
 
 
 def input_correct(initial_path_list: List[str]) -> Dict:
@@ -60,28 +56,33 @@ def create_targeted_paths_list(
     # If any of the user inputted file does not exist in any directory,
     # throw an exception indicating failure
     if not targeted_paths:
-        raise FileNotFoundError(
-            f"{FAIL}FAILURE: None of the user-provided file paths are"
-            + " found in the provided directory and the 'gatorgrade.yml' is NOT generated"
+        typer.secho(
+            "FAILURE: None of the user-provided file paths are"
+            " found in the provided directory and the 'gatorgrade.yml' is NOT generated",
+            fg=typer.colors.RED,
+            err=True,
         )
+        raise typer.Exit(1)
 
     # If some of the files are found and some are not found,
     # output a warning message saying which files were not found
     targeted_paths_string = " ".join(targeted_paths)
     for key in target_path_list:
         if key not in targeted_paths_string:
-            print(
-                f"{WARNING}WARNING \N{Warning Sign}: '{key}' file path is not FOUND!"
-                + f"\nAll file paths except '{key}' are successfully"
-                + " generated in the 'gatorgrade.yml' file"
+            typer.secho(
+                f"WARNING \u26A0: '{key}' file path is not FOUND!"
+                f"\nAll file paths except '{key}' are successfully"
+                " generated in the 'gatorgrade.yml' file",
+                fg=typer.colors.YELLOW,
             )
             return targeted_paths
 
     # If all the files exist in the root directory, print out a success message
     if targeted_paths:
-        print(
-            f"{OKGREEN}SUCCESS \N{Fire}: All the file paths were"
-            + " successfully generated in the 'gatorgrade.yml' file!"
+        typer.secho(
+            "SUCCESS \U0001F525: All the file paths were"
+            " successfully generated in the 'gatorgrade.yml' file!",
+            fg=typer.colors.GREEN,
         )
 
     return targeted_paths

--- a/gatorgrade/input/set_up_shell.py
+++ b/gatorgrade/input/set_up_shell.py
@@ -1,6 +1,7 @@
 """Set-up the shell commands."""
+
 import subprocess
-import sys
+import typer
 
 
 def run_setup(front_matter):
@@ -14,7 +15,7 @@ def run_setup(front_matter):
     # If setup exists in the front matter
     setup = front_matter.get("setup")
     if setup:
-        print("Running set up commands...")
+        typer.echo("Running set up commands...")
         for line in setup.splitlines():
             # Trims the white space
             command = line.strip()
@@ -22,12 +23,13 @@ def run_setup(front_matter):
             proc = subprocess.run(command, shell=True, check=False, timeout=300)
             # If the exit code tells it was unsuccessful and did not return 0
             if proc.returncode != 0:
-                print(
+                typer.secho(
                     f'The set up command "{command}" failed.\
                 Exiting GatorGrade.',
-                    file=sys.stderr,
+                    err=True,
+                    fg=typer.colors.RED,
                 )
                 # If a set up command failed, exit the execution
                 # because environment was not set up correctly.
-                sys.exit(1)
-        print("Finished!\n")
+                raise typer.Exit(1)
+        typer.echo("Finished!\n")

--- a/gatorgrade/output/output_functions.py
+++ b/gatorgrade/output/output_functions.py
@@ -4,12 +4,9 @@ The requested functions are located at the Github Issue Tracker
 for the output team. For instance, functions dealing with percentage
 output, description output, and colorization of text.
 """
-
+import typer
 import gator
-import colorama as color
 from gatorgrade.output import output_percentage_printing
-
-color.init()
 
 
 def run_commands_and_return_results(commands_input):
@@ -85,7 +82,8 @@ def output_passed_checks(passed_checks):
     for check in passed_checks:
         requirement = check[0]
         # Use colorama to style passing check
-        print(f"{color.Fore.GREEN}\u2714  {color.Style.RESET_ALL}{requirement}")
+        typer.secho("\u2714  ", nl=False, fg=typer.colors.GREEN)
+        typer.echo(requirement)
 
 
 def output_failed_checks(failed_checks):
@@ -95,8 +93,9 @@ def output_failed_checks(failed_checks):
         requirement = check[0]
         description = check[2]
         # Use colorama to print and style "X"
-        print(f"{color.Fore.RED}\u2718  {color.Style.RESET_ALL}{requirement}")
-        print(f"    {color.Fore.YELLOW}\u2192  {description}{color.Style.RESET_ALL}")
+        typer.secho("\u2718  ", nl=False, fg=typer.colors.RED)
+        typer.echo(requirement)
+        typer.secho(f"    \u2192  {description}", fg=typer.colors.YELLOW)
 
 
 def run_and_display_command_checks(commands):
@@ -118,4 +117,4 @@ def run_and_display_command_checks(commands):
     """
     results = run_commands_and_return_results(commands)
     display_check_results(results)
-    print(output_percentage_printing.print_percentage(results))
+    typer.echo(output_percentage_printing.print_percentage(results))

--- a/gatorgrade/output/output_percentage_printing.py
+++ b/gatorgrade/output/output_percentage_printing.py
@@ -1,5 +1,5 @@
 """Output with the percentage of checks that the student has met requirments."""
-import colorama as color
+import typer
 
 
 def print_percentage(results):
@@ -11,16 +11,21 @@ def print_percentage(results):
             true_list.append(result)
     math = len(true_list) / len(results)  # procedure of math right/total
     percent = math * 100  # get the percent to non decimal.
+    result = ""
     if percent == 100.0:
-        return (
-            color.Fore.GREEN
-            + "|=====================================|\n"
-            + f"|Passing all GatorGrader Checks {percent}%|\n"
-            + "|=====================================|"
-            + color.Style.RESET_ALL
+        result += typer.style(
+            "|=====================================|\n",
+            fg=typer.colors.GREEN,
+            reset=False,
+        )
+        result += typer.style(
+            f"|Passing all GatorGrader Checks {percent}%|\n", reset=False
+        )
+        result += typer.style("|=====================================|")
+    else:
+        result += typer.style(
+            f"Passing {len(true_list)}/{len(results)}, Grade is {percent}%.",
+            fg=typer.colors.RED,
         )
 
-    return (
-        f"\n{color.Fore.RED}Passing {len(true_list)}/{len(results)}, "
-        f"Grade is {percent}%.\n{color.Style.RESET_ALL}"
-    )
+    return result

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -3,6 +3,7 @@
 # Import needed libraries
 import os
 import pytest
+import typer
 from gatorgrade.generate.generate import generate_config
 
 
@@ -131,7 +132,7 @@ def test_generate_should_produce_warning_message_when_some_user_inputted_files_d
 
 
 def test_generate_should_throw_an_error_when_none_of_user_provided_files_exist(
-    tmp_path,
+    tmp_path, capsys
 ):
     """Check if generate.py throws an error and produce a failure message
     when none of user provided file paths exist in the root directory"""
@@ -159,10 +160,13 @@ def test_generate_should_throw_an_error_when_none_of_user_provided_files_exist(
     # When we call the modularized version of "generate.py"
     # with two arguments, but none of the files exist in the root directory
 
-    with pytest.raises(FileNotFoundError) as exc_info:
+    with pytest.raises(typer.Exit) as exc_info:
         generate_config(["tests", "README.md"], str(root_directory))
 
-    # Then "gatorgrade.yml" should not be generated and generate.py should throw a FileNotFoundError
+    _, err = capsys.readouterr()
+
+    # Then "gatorgrade.yml" should not be generated and generate.py should throw a typer.Exit
     file = root_directory / "gatorgrade.yml"
     assert not file.is_file()
-    assert "'gatorgrade.yml' is NOT generated" in str(exc_info.value)
+    assert "'gatorgrade.yml' is NOT generated" in err
+    assert exc_info.value.exit_code == 1

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,18 +1,14 @@
 """ Tests to ensure the output_functions.py functions work properly. """
 
 import pytest
-import colorama as color
 from gatorgrade.output import output_functions
 
-color.init()
 
-
-@pytest.fixture()
 def test_output_shows_green(capsys):
     """Test for ouput of a passed check will show green check."""
     output_functions.output_passed_checks([("Remove All TODOs", True, "")])
     out, err = capsys.readouterr()
-    expected_output = f"{color.Fore.GREEN}\u2714"
+    expected_output = f"\u2714"
 
     actual_output = out
     assert expected_output in actual_output
@@ -26,7 +22,7 @@ def test_output_shows_red(capsys):
     )
     out, err = capsys.readouterr()
 
-    expected_output = f"{color.Fore.RED}"
+    expected_output = f""
     actual_output = out
     assert expected_output in actual_output
     assert err == ""
@@ -38,7 +34,7 @@ def test_output_shows_yellow(capsys):
         [("Remove all TODOs", False, "3 TODOs found in example.py")]
     )
     out, err = capsys.readouterr()
-    expected_output = f"{color.Fore.YELLOW}\u2192"
+    expected_output = f"\u2192"
     actual_output = out
     assert expected_output in actual_output
     assert err == ""
@@ -50,7 +46,7 @@ def test_descrition_in_fail_message(capsys):
         [("Implement this with an if.", False, "No if statements found")]
     )
     out, err = capsys.readouterr()
-    expected_output = f"{color.Fore.YELLOW}→  No if statements found"
+    expected_output = f"→  No if statements found"
     actual_output = out
     assert expected_output in actual_output
     assert "" in err

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -15,6 +15,17 @@ def test_description_in_fail_message(capsys):
     assert "" in err
 
 
+def test_passed_result_returns_check(capsys):
+    """Test will result a check mark in the output for the passed check."""
+    output_functions.output_passed_checks([("Remove All TODOs", True, "")])
+    out, err = capsys.readouterr()
+    expected_output = f"\u2714"
+
+    actual_output = out
+    assert expected_output in actual_output
+    assert err == ""
+
+
 def test_false_result_returns_x(capsys):
     """Test will result a X mark in the output for the failed check."""
     output_functions.output_failed_checks(

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,40 +1,30 @@
-""" Tests to ensure the output_functions.py functions work properly. """
+""" Tests to ensure the output_functions.py functions work properly."""
 
 from gatorgrade.output import output_functions
 
 
-def test_description_in_fail_message(capsys):
-    """Testing the failed check will show diagnostic yellow message in output."""
-    output_functions.output_failed_checks(
-        [("Implement this with an if.", False, "No if statements found")]
-    )
-    out, err = capsys.readouterr()
-    expected_output = f"→  No if statements found"
-    actual_output = out
-    assert expected_output in actual_output
-    assert "" in err
-
-
 def test_passed_result_returns_check(capsys):
-    """Test will result a check mark in the output for the passed check."""
+    """Verify that output contains a check mark for a passed check."""
     output_functions.output_passed_checks([("Remove All TODOs", True, "")])
-    out, err = capsys.readouterr()
-    expected_output = f"\u2714"
 
-    actual_output = out
-    assert expected_output in actual_output
+    out, err = capsys.readouterr()
+    assert "✔" in out
     assert err == ""
 
 
-def test_false_result_returns_x(capsys):
-    """Test will result a X mark in the output for the failed check."""
-    output_functions.output_failed_checks(
-        [("Implement this with an if.", False, "No if statements found")]
-    )
-    out, err = capsys.readouterr()
-    unicode_x = "\u2718"
-    expected_output = unicode_x
-    actual_output = out
+def test_failed_result_contains_diagnostic(capsys):
+    """Verify that output contains a diagnostic for a failed check."""
+    output_functions.output_failed_checks([("Remove All TODOs", False, "More TODOs")])
 
-    assert expected_output in actual_output
+    out, err = capsys.readouterr()
+    assert "→  More TODOs" in out
+    assert err == ""
+
+
+def test_failed_result_returns_cross(capsys):
+    """Verify that output contains a cross mark for a failed check."""
+    output_functions.output_failed_checks([("Remove All TODOs", False, "More TODOs")])
+
+    out, err = capsys.readouterr()
+    assert "✘" in out
     assert err == ""

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,46 +1,9 @@
 """ Tests to ensure the output_functions.py functions work properly. """
 
-import pytest
 from gatorgrade.output import output_functions
 
 
-def test_output_shows_green(capsys):
-    """Test for ouput of a passed check will show green check."""
-    output_functions.output_passed_checks([("Remove All TODOs", True, "")])
-    out, err = capsys.readouterr()
-    expected_output = f"\u2714"
-
-    actual_output = out
-    assert expected_output in actual_output
-    assert err == ""
-
-
-def test_output_shows_red(capsys):
-    """Test for output of failed check to show red color using Colorama."""
-    output_functions.output_failed_checks(
-        [("Remove all TODOs", False, "3 TODOs found in example.py")]
-    )
-    out, err = capsys.readouterr()
-
-    expected_output = f""
-    actual_output = out
-    assert expected_output in actual_output
-    assert err == ""
-
-
-def test_output_shows_yellow(capsys):
-    """Testing the failed check will show a yellow message in output."""
-    output_functions.output_failed_checks(
-        [("Remove all TODOs", False, "3 TODOs found in example.py")]
-    )
-    out, err = capsys.readouterr()
-    expected_output = f"\u2192"
-    actual_output = out
-    assert expected_output in actual_output
-    assert err == ""
-
-
-def test_descrition_in_fail_message(capsys):
+def test_description_in_fail_message(capsys):
     """Testing the failed check will show diagnostic yellow message in output."""
     output_functions.output_failed_checks(
         [("Implement this with an if.", False, "No if statements found")]

--- a/tests/test_output_percentage_print.py
+++ b/tests/test_output_percentage_print.py
@@ -20,7 +20,7 @@ def test_given_results_returns_percent_incorrect():
         ("Have a total of 8 commits, 5 of which were created by you", True, ""),
     ]
 
-    expected_result = "\n\x1b[31mPassing 3/5, Grade is 60.0%.\n"
+    expected_result = "Passing 3/5, Grade is 60.0%."
     actual_result = output_percentage_printing.print_percentage(results)
     assert expected_result in actual_result
 


### PR DESCRIPTION
# Switch to using Typer user interactions

## Description

Previously Colorama and native exceptions were used to print output and fail on errors. This PR updates everything to use `typer.style` and `typer.echo` (or `typer.secho`) for better compatibility for testing.


## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation

## Contributors

- @Michionlion 

## Reminder

 - All GitHub Actions should be in a passing state before any pull request is merged.
 - All PRs must be reviewed by at least one team member and one member of the Integration team!
 - Any issues this PR closes are tagged in the description!
