### PR TITLE
Remove the generate function from the CLI in the --help message

### DIFF
--- a/gatorgrade/main.py
+++ b/gatorgrade/main.py
@@ -10,7 +10,17 @@ from gatorgrade.input.parse_config import parse_config
 from gatorgrade.output.output import run_checks
 
 # create an app for the Typer-based CLI
-app = typer.Typer(add_completion=False)
+
+# define the emoji that will be prepended to the help message
+gatorgrade_emoji = "🐊"
+
+# create a Typer app that
+# --> does not support completion
+# --> has a specified help message with an emoji
+app = typer.Typer(
+    add_completion=False,
+    help=f"{gatorgrade_emoji} Run the GatorGrader checks in the specified gatorgrade.yml file.",
+)
 
 # create a default console for printing with rich
 console = Console()

--- a/gatorgrade/main.py
+++ b/gatorgrade/main.py
@@ -25,7 +25,7 @@ def gatorgrade(
     ctx: typer.Context,
     filename: Path = typer.Option(FILE, "--config", "-c", help="Name of the yml file."),
 ):
-    """Run the GatorGrader checks in the gatorgrade.yml file."""
+    """Run the GatorGrader checks in the specified gatorgrade.yml file."""
     # if ctx.subcommand is None then this means
     # that, by default, gatorgrade should run in checking mode
     if ctx.invoked_subcommand is None:

--- a/gatorgrade/main.py
+++ b/gatorgrade/main.py
@@ -1,14 +1,11 @@
 """Use Typer to run gatorgrade to run the checks and generate the yml file."""
 
-# import glob
 import sys
 from pathlib import Path
-# from typing import List
 
 import typer
 from rich.console import Console
 
-# from gatorgrade.generate.generate import generate_config
 from gatorgrade.input.parse_config import parse_config
 from gatorgrade.output.output import run_checks
 

--- a/gatorgrade/main.py
+++ b/gatorgrade/main.py
@@ -55,26 +55,26 @@ def gatorgrade(
             sys.exit(FAILURE)
 
 
-@app.command()
-def generate(
-    root: Path = typer.Argument(
-        Path("."),
-        help="Root directory of the assignment",
-        exists=True,
-        dir_okay=True,
-        writable=True,
-    ),
-    paths: List[Path] = typer.Option(
-        ["*"],
-        help="Paths to recurse through and generate checks for",
-        exists=False,
-    ),
-):
-    """Generate a gatorgrade.yml file."""
-    targets = []
-    for path in paths:
-        targets.extend(glob.iglob(path.as_posix(), recursive=True))
-    generate_config(targets, root.as_posix())
+# @app.command()
+# def generate(
+#     root: Path = typer.Argument(
+#         Path("."),
+#         help="Root directory of the assignment",
+#         exists=True,
+#         dir_okay=True,
+#         writable=True,
+#     ),
+#     paths: List[Path] = typer.Option(
+#         ["*"],
+#         help="Paths to recurse through and generate checks for",
+#         exists=False,
+#     ),
+# ):
+#     """Generate a gatorgrade.yml file."""
+#     targets = []
+#     for path in paths:
+#         targets.extend(glob.iglob(path.as_posix(), recursive=True))
+#     generate_config(targets, root.as_posix())
 
 
 if __name__ == "__main__":

--- a/gatorgrade/main.py
+++ b/gatorgrade/main.py
@@ -23,7 +23,7 @@ FAILURE = 1
 @app.callback(invoke_without_command=True)
 def gatorgrade(
     ctx: typer.Context,
-    filename: Path = typer.Option(FILE, "--config", "-c", help="Name of the yml file."),
+    filename: Path = typer.Option(FILE, "--config", "-c", help="Name of the YML file."),
 ):
     """Run the GatorGrader checks in the specified gatorgrade.yml file."""
     # if ctx.subcommand is None then this means

--- a/gatorgrade/main.py
+++ b/gatorgrade/main.py
@@ -1,14 +1,14 @@
 """Use Typer to run gatorgrade to run the checks and generate the yml file."""
 
-import glob
+# import glob
 import sys
 from pathlib import Path
-from typing import List
+# from typing import List
 
 import typer
 from rich.console import Console
 
-from gatorgrade.generate.generate import generate_config
+# from gatorgrade.generate.generate import generate_config
 from gatorgrade.input.parse_config import parse_config
 from gatorgrade.output.output import run_checks
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,25 +58,25 @@ def cleanup_files(monkeypatch):
         os.remove(file)
 
 
-def test_generate_creates_valid_yml():
-    """Ensure that the generate command creates the .yml file correctly."""
-    result = runner.invoke(main.app, ["generate"])
-    print(result.stdout)
-    assert result.exit_code == 0
+# def test_generate_creates_valid_yml():
+#     """Ensure that the generate command creates the .yml file correctly."""
+#     result = runner.invoke(main.app, ["generate"])
+#     print(result.stdout)
+#     assert result.exit_code == 0
 
 
-def test_generate_fails_with_existing_yml():
-    """Ensure that a second yml file isn't generated without the force command."""
-    result = runner.invoke(main.app, ["generate"])
-    print(result.stdout)
-    assert result.exit_code == 0
+# def test_generate_fails_with_existing_yml():
+#     """Ensure that a second yml file isn't generated without the force command."""
+#     result = runner.invoke(main.app, ["generate"])
+#     print(result.stdout)
+#     assert result.exit_code == 0
 
 
-def test_generate_force_option_creates_yml():
-    """Ensure that the force command works correctly."""
-    result = runner.invoke(main.app, ["generate"])
-    print(result.stdout)
-    assert result.exit_code == 0
+# def test_generate_force_option_creates_yml():
+#     """Ensure that the force command works correctly."""
+#     result = runner.invoke(main.app, ["generate"])
+#     print(result.stdout)
+#     assert result.exit_code == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- TODO: Replace the title below -->
# Remove the generate function so it is not advertised through the CLI

## Description

Right now the `--generate` flag is not in regular use. This feature does not contain everything that would be useful for it as it does not yet create all of the checks for the files in a specific directory structure. As such, this PR removes this feature until it can be enhanced further. Note, the PR does not remove the underlying code but rather the way in which it is advertised through the command-line interface. This will help to avoid people trying a feature and seeing that it does not match their expectations.

Finally, this PR improves the help message generated when you use the `--help` command-line argument.

## Linked Issues

None

## Type of Change

<!-- TODO: Fill in the brackets with an `x` next to all types that apply to the proposed changes -->
- [ ] Feature
- [X] Bug fix
- [ ] Documentation

## Contributors

<!-- TODO: Add your GitHub username below and the GitHub usernames of all other contributors to the proposed changes -->
- @gkapfhamn

## Reminder

 - [X]  All GitHub Actions should be in a passing state before any pull request is merged.
 - [X]  All PRs must be reviewed by at least one team member and one member of the Integration team!
 - [X]  Any issues this PR closes are tagged in the description!
