### PR TITLE
Use unicode symbols that are more likely to work correctly on Windows

### DIFF
--- a/gatorgrade/output/check_result.py
+++ b/gatorgrade/output/check_result.py
@@ -2,10 +2,6 @@
 
 import rich
 
-import unicodedata
-
-UTF_ENCODE = "utf-8"
-
 
 class CheckResult:  # pylint: disable=too-few-public-methods
     """Represent the result of running a check."""

--- a/gatorgrade/output/check_result.py
+++ b/gatorgrade/output/check_result.py
@@ -1,5 +1,10 @@
 """Define check result class."""
+
 import rich
+
+import unicodedata
+
+UTF_ENCODE = "utf-8"
 
 
 class CheckResult:  # pylint: disable=too-few-public-methods
@@ -32,7 +37,7 @@ class CheckResult:  # pylint: disable=too-few-public-methods
             show_diagnostic: If true, show the diagnostic message if the check has failed.
                 Defaults to false.
         """
-        icon = "" if self.passed else "✘"
+        icon = "✓" if self.passed else "✕"
         icon_color = "green" if self.passed else "red"
         message = f"[{icon_color}]{icon}[/]  {self.description}"
         if not self.passed and show_diagnostic:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gatorgrade"
-version = "0.3.0"
+version = "0.3.1"
 description = "GatorGrade executes GatorGrader checks!"
 authors = ["Michael Abraham", "Jacob Allebach", "Liam Black", "Katherine Burgess", "Yanqiao Chen", "Ochirsaikhan Davaajambal", "Tuguldurnemekh Gantulga", "Anthony Grant-Cook", "Dylan Holland", "Gregory M. Kapfhammer", "Peyton Kelly", "Luke Lacaria", "Lauren Nevill", "Jack Turner", "Daniel Ullrich", "Garrison Vanzin", "Rian Watson"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "gatorgrade"
 version = "0.3.0"
-description = "Python tool to execute GatorGrader"
+description = "GatorGrade executes GatorGrader checks!"
 authors = ["Michael Abraham", "Jacob Allebach", "Liam Black", "Katherine Burgess", "Yanqiao Chen", "Ochirsaikhan Davaajambal", "Tuguldurnemekh Gantulga", "Anthony Grant-Cook", "Dylan Holland", "Gregory M. Kapfhammer", "Peyton Kelly", "Luke Lacaria", "Lauren Nevill", "Jack Turner", "Daniel Ullrich", "Garrison Vanzin", "Rian Watson"]
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "gatorgrade"
 version = "0.3.1"
 description = "GatorGrade executes GatorGrader checks!"
 authors = ["Michael Abraham", "Jacob Allebach", "Liam Black", "Katherine Burgess", "Yanqiao Chen", "Ochirsaikhan Davaajambal", "Tuguldurnemekh Gantulga", "Anthony Grant-Cook", "Dylan Holland", "Gregory M. Kapfhammer", "Peyton Kelly", "Luke Lacaria", "Lauren Nevill", "Jack Turner", "Daniel Ullrich", "Garrison Vanzin", "Rian Watson"]
+readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"

--- a/tests/output/test_output.py
+++ b/tests/output/test_output.py
@@ -28,7 +28,7 @@ def test_run_checks_gg_check_should_show_passed(capsys):
     output.run_checks([check])
     # Then the output shows that the check has passed
     out, _ = capsys.readouterr()
-    assert "  Check TODOs" in out
+    assert "✓  Check TODOs" in out
 
 
 def test_run_checks_invalid_gg_args_prints_exception(capsys):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -87,8 +87,8 @@ def cleanup_files(monkeypatch):
             [
                 ("Complete all TODOs", 2),
                 ("Use an if statement", 1),
-                ("", 3),
-                ("✘", 0),
+                ("✓", 3),
+                ("✕", 0),
                 ("Passed 3/3 (100%) of checks", 1),
             ],
         )


### PR DESCRIPTION
<!-- TODO: Replace the title below -->
# Use symbols for checkmark and xmark that are more likely to work on Windows

This PR changes the following line of source code to what is listed below:

```python
        icon = "✓" if self.passed else "✕"
```

It attempts to use Unicode symbols that will not cause Python to crash when running GatorGrade on `windows-latest` in GitHub actions. Note that this happens when running `gatorgrade` in projects but not when running tests in CI for this project. Sadly, these two characters do not look very similar to each other (i.e., the checkmark is smaller than the xmark) but it seems as though these are the most platform-independent characters to use for most terminal windows.

You can install this version by running the following command: 

```
pipx install git+https://github.com/GatorEducator/gatorgrade.git@fix/utf-encode
```

Note that this PR also sets the `readme` attribute so that more information appears in the PyPI web site listing.

<!-- TODO: Fill in the brackets with an `x` next to all types that apply to the proposed changes -->
- [ ] Feature
- [X] Bug fix
- [ ] Documentation

## Contributors

<!-- TODO: Add your GitHub username below and the GitHub usernames of all other contributors to the proposed changes -->
- @gkapfham 