### PR TITLE
bug: fix display diagnosis msg in terminal

### DIFF
--- a/gatorgrade/output/check_result.py
+++ b/gatorgrade/output/check_result.py
@@ -37,7 +37,7 @@ class CheckResult:  # pylint: disable=too-few-public-methods
         icon_color = "green" if self.passed else "red"
         message = f"[{icon_color}]{icon}[/]  {self.description}"
         if not self.passed and show_diagnostic:
-            message = f"[yellow]   → {self.diagnostic}"
+            message += f"\n[yellow]   → {self.diagnostic}"
         return message
 
     def __str__(self, show_diagnostic: bool = False) -> str:
@@ -61,5 +61,5 @@ class CheckResult:  # pylint: disable=too-few-public-methods
             show_diagnostic: If true, show the diagnostic message if the check has failed.
                 Defaults to false.
         """
-        message = self.display_result()
+        message = self.display_result(show_diagnostic)
         rich.print(message)


### PR DESCRIPTION
<!-- TODO: Replace the title below -->
# Fixed display diagnosis message 
Fixed a bug about there is no diagnosis message report in terminal. Diagnosis report like found 10 counts, expect 12 count didn't show up in the terminal as expected. I fixed this bug and it currently shows up correctly
## Description

<!-- TODO: Write a description of the proposed changes -->
<!-- Remember to check the reminders! -->

## Linked Issues

<!-- Fill in which issue number this PR closes, if there is none, just remove this section! -->
closes: #00

## Type of Change

<!-- TODO: Fill in the brackets with an `x` next to all types that apply to the proposed changes -->
- [ ] Feature
- [x] Bug fix
- [ ] Documentation

## Contributors

<!-- TODO: Add your GitHub username below and the GitHub usernames of all other contributors to the proposed changes -->
- @Yanqiao4396 

## Reminder

 - All GitHub Actions should be in a passing state before any pull request is merged.
 - All PRs must be reviewed by at least one team member and one member of the Integration team!
 - Any issues this PR closes are tagged in the description!
