### PR TITLE
Fix Attribute Error: 'HTTPResponse' object has no attribute 'strict'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v7
         with:
-          poetry-version: 1.4.2
+          poetry-version: 1.2.1
       - name: Setup Poetry
         run: |
           poetry --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v7
         with:
-          poetry-version: 1.4.2
+          poetry-version: 1.5.0
       - name: Setup Poetry
         run: |
           poetry --version
@@ -87,7 +87,7 @@ jobs:
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v7
         with:
-          poetry-version: 1.4.2
+          poetry-version: 1.5.0
       - name: Setup Poetry
         run: |
           poetry --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,6 @@ jobs:
         id: setup-python
         with:
           python-version: 3.7
-      # - name: Install Dependency
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     pip install 'urllib3<2'
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v7
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v7
         with:
-          poetry-version: 1.1.13
+          poetry-version: 1.4.2
       - name: Setup Poetry
         run: |
           poetry --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,10 @@ jobs:
         id: setup-python
         with:
           python-version: 3.7
+      - name: Install Dependency
+        run: |
+          python -m pip install --upgrade pip
+          pip install 'urllib3<2'
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v7
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,14 +24,14 @@ jobs:
         id: setup-python
         with:
           python-version: 3.7
-      - name: Install Dependency
-        run: |
-          python -m pip install --upgrade pip
-          pip install 'urllib3<2'
+      # - name: Install Dependency
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     pip install 'urllib3<2'
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v7
         with:
-          poetry-version: 1.2.1
+          poetry-version: 1.4.2
       - name: Setup Poetry
         run: |
           poetry --version
@@ -91,7 +91,7 @@ jobs:
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v7
         with:
-          poetry-version: 1.1.13
+          poetry-version: 1.4.2
       - name: Setup Poetry
         run: |
           poetry --version

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,6 +25,7 @@ python-versions = "*"
 
 [package.dependencies]
 six = ">=1.6.1,<2.0"
+wheel = ">=0.23.0,<1.0"
 
 [[package]]
 name = "attrs"
@@ -922,11 +923,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.12"
+version = "1.26.15"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
@@ -943,6 +944,17 @@ python-versions = ">=3.6"
 
 [package.extras]
 watchmedo = ["PyYAML (>=3.10)"]
+
+[[package]]
+name = "wheel"
+version = "0.40.0"
+description = "A built-package format for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6.0.0)"]
 
 [[package]]
 name = "wrapt"
@@ -967,7 +979,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.2,<4.0"
-content-hash = "745764366191be2cf495072bee0fe1c94fad711bdfd962cfa831085aacd9e56d"
+content-hash = "9863a5a8a526c0bc3db80fb5863a842f756895c74d10770410b8061f894c1b4f"
 
 [metadata.files]
 astroid = [
@@ -1506,8 +1518,8 @@ typing-extensions = [
     {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
-    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
+    {file = "urllib3-1.26.15-py2.py3-none-any.whl", hash = "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"},
+    {file = "urllib3-1.26.15.tar.gz", hash = "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305"},
 ]
 watchdog = [
     {file = "watchdog-2.1.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a735a990a1095f75ca4f36ea2ef2752c99e6ee997c46b0de507ba40a09bf7330"},
@@ -1535,6 +1547,10 @@ watchdog = [
     {file = "watchdog-2.1.9-py3-none-win_amd64.whl", hash = "sha256:7a833211f49143c3d336729b0020ffd1274078e94b0ae42e22f596999f50279c"},
     {file = "watchdog-2.1.9-py3-none-win_ia64.whl", hash = "sha256:ad576a565260d8f99d97f2e64b0f97a48228317095908568a9d5c786c829d428"},
     {file = "watchdog-2.1.9.tar.gz", hash = "sha256:43ce20ebb36a51f21fa376f76d1d4692452b2527ccd601950d69ed36b9e21609"},
+]
+wheel = [
+    {file = "wheel-0.40.0-py3-none-any.whl", hash = "sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247"},
+    {file = "wheel-0.40.0.tar.gz", hash = "sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873"},
 ]
 wrapt = [
     {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ PyYAML = "^6.0"
 gatorgrader = "^1.1.1"
 rich = "^12.5.1"
 typer = {extras = ["all"], version = "^0.6.1"}
+urllib3 = "<=2.0"
 
 [tool.poetry.dev-dependencies]
 taskipy = "^1.10.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ PyYAML = "^6.0"
 gatorgrader = "^1.1.1"
 rich = "^12.5.1"
 typer = {extras = ["all"], version = "^0.6.1"}
-urllib3 = "<=2.0"
 
 [tool.poetry.dev-dependencies]
 taskipy = "^1.10.1"


### PR DESCRIPTION
<!-- TODO: Replace the title below -->
# Requests Incompatibility Problem

## Description

Current Poetry version will return error
<!-- TODO: Write a description of the proposed changes -->
<!-- Remember to check the reminders! -->
```
AttributeError

  'HTTPResponse' object has no attribute 'strict'

  at ~/.local/share/pypoetry/venv/lib/python3.7/site-packages/cachecontrol/serialize.py:54 in dumps
       50│                 ),
       51│                 u"status": response.status,
       52│                 u"version": response.version,
       53│                 u"reason": text_type(response.reason),
    →  54│                 u"strict": response.strict,
       55│                 u"decode_content": response.decode_content,
       56│             }
       57│         }
       58│
```

To fix this problem, the easiest workaround is to upgrade Poetry over 1.2. Here I upgraded the automatic build of Poetry in `.GitHub/workflow/main.yml` to `1.4.2`
## Linked Issues

More discussions about this error could be found in https://github.com/ionrock/cachecontrol/issues/292
<!-- Fill in which issue number this PR closes, if there is none, just remove this section! -->
closes: #00

## Type of Change

<!-- TODO: Fill in the brackets with an `x` next to all types that apply to the proposed changes -->
- [ ] Feature
- [ x ] Bug fix
- [ ] Documentation

## Contributors

<!-- TODO: Add your GitHub username below and the GitHub usernames of all other contributors to the proposed changes -->
- @

