### PR TITLE
Bug: json dumps replaces str

### DIFF
--- a/gatorgrade/output/output.py
+++ b/gatorgrade/output/output.py
@@ -230,7 +230,7 @@ def configure_report(
         # Add json report into the GITHUB_ENV environment variable for data collection purpose
         env_file = os.getenv("GITHUB_ENV")
         with open(env_file, "a") as myfile:
-            myfile.write(f"JSON_REPORT={json.dumps(report_output_data_json,indent=4)}")
+            myfile.write(f"JSON_REPORT={json.dumps(report_output_data_json)}")
         # Add env
     else:
         raise ValueError(

--- a/gatorgrade/output/output.py
+++ b/gatorgrade/output/output.py
@@ -230,7 +230,7 @@ def configure_report(
         # Add json report into the GITHUB_ENV environment variable for data collection purpose
         env_file = os.getenv("GITHUB_ENV")
         with open(env_file, "a") as myfile:
-            myfile.write(f"JSON_REPORT={report_output_data_json}")
+            myfile.write(f"JSON_REPORT={json.dumps(report_output_data_json,indent=4)}")
         # Add env
     else:
         raise ValueError(


### PR DESCRIPTION
used to use dict type and failed as dict is not
equal to json type. Now put json type into JSON_REPORT correctly

<!-- TODO: Replace the title below -->
# json dumps
## Description
Store json dumps instead of dictionary into the JSON_REPORT environment variable
<!-- TODO: Write a description of the proposed changes -->
<!-- Remember to check the reminders! -->

## Linked Issues

<!-- Fill in which issue number this PR closes, if there is none, just remove this section! -->
closes: #00

## Type of Change

<!-- TODO: Fill in the brackets with an `x` next to all types that apply to the proposed changes -->
- [ ] Feature
- [x] Bug fix
- [ ] Documentation

## Contributors

<!-- TODO: Add your GitHub username below and the GitHub usernames of all other contributors to the proposed changes -->
- @Yanqiao4396 

## Reminder

 - All GitHub Actions should be in a passing state before any pull request is merged.
 - All PRs must be reviewed by at least one team member and one member of the Integration team!
 - Any issues this PR closes are tagged in the description!
