### PR TITLE
Add Path Attribute to the CheckResult and Test Customized Insight Key Value Pair

### DIFF
--- a/gatorgrade/output/check_result.py
+++ b/gatorgrade/output/check_result.py
@@ -11,6 +11,7 @@ class CheckResult:  # pylint: disable=too-few-public-methods
         passed: bool,
         description: str,
         json_info,
+        path: str = None,
         diagnostic: str = "No diagnostic message available",
     ):
         """Construct a CheckResult.
@@ -26,6 +27,7 @@ class CheckResult:  # pylint: disable=too-few-public-methods
         self.description = description
         self.json_info = json_info
         self.diagnostic = diagnostic
+        self.path = path
 
     def display_result(self, show_diagnostic: bool = False) -> str:
         """Print check's passed or failed status, description, and, optionally, diagnostic message.

--- a/gatorgrade/output/output.py
+++ b/gatorgrade/output/output.py
@@ -74,7 +74,7 @@ def _run_gg_check(check: GatorGraderCheck) -> CheckResult:
             if check.gg_args[i] == "--directory":
                 dir_name = check.gg_args[i + 1]
                 file_name = check.gg_args[i + 3]
-                file_path = os.path.join(dir_name, file_name)
+                file_path = dir_name + "/" + file_name
                 break
     # If arguments are formatted incorrectly, catch the exception and
     # return it as the diagnostic message

--- a/gatorgrade/output/output.py
+++ b/gatorgrade/output/output.py
@@ -118,7 +118,8 @@ def create_report_json(
         # grab all of the information in it and add it to the checks list
         results_json = checkResults[i].json_info
         results_json["status"] = checkResults[i].passed
-        results_json["path"] = checkResults[i].path
+        if checkResults[i].path:
+            results_json["path"] = checkResults[i].path
         if not checkResults[i].passed:
             results_json["diagnostic"] = checkResults[i].diagnostic
         checks_list.append(results_json)

--- a/gatorgrade/output/output.py
+++ b/gatorgrade/output/output.py
@@ -65,6 +65,17 @@ def _run_gg_check(check: GatorGraderCheck) -> CheckResult:
         passed = result[1]
         description = result[0]
         diagnostic = result[2]
+
+        # Fetch the path from gatorgrade arguments
+        # the path pattern are 4 consistent string in the list
+        # --dir `dir_name` --file `file_name`
+        file_path = None
+        for i in range(len(check.gg_args)):
+            if check.gg_args[i] == "--directory":
+                dir_name = check.gg_args[i + 1]
+                file_name = check.gg_args[i + 3]
+                file_path = os.path.join(dir_name, file_name)
+                break
     # If arguments are formatted incorrectly, catch the exception and
     # return it as the diagnostic message
     # Disable pylint to catch any type of exception thrown by GatorGrader
@@ -72,11 +83,13 @@ def _run_gg_check(check: GatorGraderCheck) -> CheckResult:
         passed = False
         description = f'Invalid GatorGrader check: "{" ".join(check.gg_args)}"'
         diagnostic = f'"{command_exception.__class__}" thrown by GatorGrader'
+        file_path = None
     return CheckResult(
         passed=passed,
         description=description,
         json_info=check.json_info,
         diagnostic=diagnostic,
+        path=file_path,
     )
 
 
@@ -105,6 +118,7 @@ def create_report_json(
         # grab all of the information in it and add it to the checks list
         results_json = checkResults[i].json_info
         results_json["status"] = checkResults[i].passed
+        results_json["path"] = checkResults[i].path
         if not checkResults[i].passed:
             results_json["diagnostic"] = checkResults[i].diagnostic
         checks_list.append(results_json)

--- a/tests/output/test_output.py
+++ b/tests/output/test_output.py
@@ -168,6 +168,7 @@ def test_json_report_file_created_correctly():
             description="Echo 'Hello!'",
             command="echo 'hello'",
             json_info={
+                "customized_key": "customized value",
                 "description": "Echo'Hello!'",
                 "options": {
                     "command ": "echo 'hello'",
@@ -191,6 +192,7 @@ def test_json_report_file_created_correctly():
             ],
             json_info={
                 "description ": "Complete all TODOs in hello - world.py ",
+                "objective": "TODO",
                 "options": {
                     "Fragment ": "TODO ",
                     "Count ": "1",
@@ -234,6 +236,7 @@ def test_json_report_file_created_correctly():
         "checks": [
             {
                 "description": "Echo'Hello!'",
+                "customized_key": "customized value",
                 "options": {
                     "command ": "echo 'hello'",
                 },
@@ -242,6 +245,7 @@ def test_json_report_file_created_correctly():
             },
             {
                 "description ": "Complete all TODOs in hello - world.py ",
+                "objective": "TODO",
                 "options": {
                     "Fragment ": "TODO ",
                     "Count ": "1",

--- a/tests/output/test_output.py
+++ b/tests/output/test_output.py
@@ -253,9 +253,7 @@ def test_json_report_file_created_correctly():
                     "File": "hello-world.py",
                 },
                 "status": False,
-                "path": os.path.join(
-                    "tests", "test_assignment", "src", "hello-world.py"
-                ),
+                "path": "tests/test_assignment/src/hello-world.py",
                 "diagnostic": "Found 0 fragment(s) in the hello-world.py or the output while expecting exactly 1",
             },
             {

--- a/tests/output/test_output.py
+++ b/tests/output/test_output.py
@@ -237,6 +237,7 @@ def test_json_report_file_created_correctly():
                 "options": {
                     "command ": "echo 'hello'",
                 },
+                "path": None,
                 "status": True,
             },
             {
@@ -248,6 +249,9 @@ def test_json_report_file_created_correctly():
                     "File": "hello-world.py",
                 },
                 "status": False,
+                "path": os.path.join(
+                    "tests", "test_assignment", "src", "hello-world.py"
+                ),
                 "diagnostic": "Found 0 fragment(s) in the hello-world.py or the output while expecting exactly 1",
             },
             {
@@ -259,6 +263,7 @@ def test_json_report_file_created_correctly():
                     "File": "hello-world.py",
                 },
                 "status": False,
+                "path": None,
                 "diagnostic": "\"<class 'gator.exceptions.InvalidSystemArgumentsError'>\" thrown by GatorGrader",
             },
         ],

--- a/tests/output/test_output.py
+++ b/tests/output/test_output.py
@@ -240,7 +240,6 @@ def test_json_report_file_created_correctly():
                 "options": {
                     "command ": "echo 'hello'",
                 },
-                "path": None,
                 "status": True,
             },
             {
@@ -265,7 +264,6 @@ def test_json_report_file_created_correctly():
                     "File": "hello-world.py",
                 },
                 "status": False,
-                "path": None,
                 "diagnostic": "\"<class 'gator.exceptions.InvalidSystemArgumentsError'>\" thrown by GatorGrader",
             },
         ],


### PR DESCRIPTION
<!-- TODO: Replace the title below -->
# Add path attributes to  the CheckResult

## Description

Path attribute helps to locate which file a command belongs to. Add path attribute to the CheckResult to easily fetch it in the json report. Also there is a tiny test of a customized json key under the check. It proves gatorgrade's capability on creating some useful key like `learning objective`
<!-- TODO: Write a description of the proposed changes -->
<!-- Remember to check the reminders! -->
here is an example output of JSON report where the `objective: TODO` is specified under the check of yaml file

<img width="821" alt="Screenshot 2023-07-05 at 9 23 37 PM" src="https://github.com/GatorEducator/gatorgrade/assets/79415648/84e50923-5fd2-477d-a636-ee54b41b137f">


<img width="512" alt="Screenshot 2023-07-05 at 9 21 59 PM" src="https://github.com/GatorEducator/gatorgrade/assets/79415648/e98d96da-0844-4030-a227-1f7d52896a7d">

## Linked Issues

<!-- Fill in which issue number this PR closes, if there is none, just remove this section! -->
closes: #00

## Type of Change

<!-- TODO: Fill in the brackets with an `x` next to all types that apply to the proposed changes -->
- [x] Feature
- [ ] Bug fix
- [ ] Documentation

## Contributors

<!-- TODO: Add your GitHub username below and the GitHub usernames of all other contributors to the proposed changes -->
- @

## Reminder

 - All GitHub Actions should be in a passing state before any pull request is merged.
 - All PRs must be reviewed by at least one team member and one member of the Integration team!
 - Any issues this PR closes are tagged in the description!
