### PR TITLE
feat: added terminal output of what command ran

### DIFF
--- a/gatorgrade/output/output.py
+++ b/gatorgrade/output/output.py
@@ -289,7 +289,6 @@ def run_checks(
         checks: The list of shell and GatorGrader checks to run.
     """
     results = []
-    # command_output = ""
     # run each of the checks
     for check in checks:
         result = None

--- a/gatorgrade/output/output.py
+++ b/gatorgrade/output/output.py
@@ -289,30 +289,41 @@ def run_checks(
         checks: The list of shell and GatorGrader checks to run.
     """
     results = []
+    command_output = []
+
+    # command_output = ""
     # run each of the checks
     for check in checks:
         result = None
         # run a shell check; this means
         # that it is going to run a command
         # in the shell as a part of a check
+        # store the command that ran
+        command_output = None
+
         if isinstance(check, ShellCheck):
             result = _run_shell_check(check)
+            command_output = check.command
         # run a check that GatorGrader implements
         elif isinstance(check, GatorGraderCheck):
-            result = _run_gg_check(check)
+            result = _run_gg_check(check)        
+
         # there were results from running checks
         # and thus they must be displayed
         if result is not None:
             result.print()
-            results.append(result)
+            results.append((result, command_output))
 
     # determine if there are failures and then display them
-    failed_results = list(filter(lambda result: not result.passed, results))
-    # only print failures list if there are failures to print
+    failed_results = list(filter(lambda result: not result[0].passed, results))
+    # print failures list if there are failures to print 
+    # and print what ShellCheck command that Gatorgrade ran
     if len(failed_results) > 0:
         print("\n-~-  FAILURES  -~-\n")
         for result in failed_results:
-            result.print(show_diagnostic=True)
+            result[0].print(show_diagnostic=True)
+            if result[1] is not None:
+                rich.print(f"[blue]   → Here is the command that ran: [green]{result[1]}")
     # determine how many of the checks passed and then
     # compute the total percentage of checks passed
     passed_count = len(results) - len(failed_results)

--- a/gatorgrade/output/output.py
+++ b/gatorgrade/output/output.py
@@ -289,8 +289,6 @@ def run_checks(
         checks: The list of shell and GatorGrader checks to run.
     """
     results = []
-    command_output = []
-
     # command_output = ""
     # run each of the checks
     for check in checks:


### PR DESCRIPTION
## Title
Feature: What command did Gatorgrader run?

## Description
This feature will allow users to know what command Gatorgrader ran to see that specific gatorgrade check passes. It prints this command in the terminal so that rather than having to pull up the gatorgrade.yml file the user can simply see the command that ran and failed in their terminal. 

## Linked Issues
[https://github.com/GatorEducator/gatorgrade/issues/131](https://github.com/GatorEducator/gatorgrade/issues/131)

<!-- Fill in which issue number this PR closes, if there is none, just remove this section! -->
closes: #131

## Type of Change

<!-- TODO: Fill in the brackets with an `x` next to all types that apply to the proposed changes -->
- [x] Feature
- [ ] Bug fix
- [ ] Documentation

## Contributors

<!-- TODO: Add your GitHub username below and the GitHub usernames of all other contributors to the proposed changes -->
- @rebekahrudd

## Reminder

 - All GitHub Actions should be in a passing state before any pull request is merged.
 - All PRs must be reviewed by at least one team member and one member of the Integration team!
 - Any issues this PR closes are tagged in the description!

Instructions for running and testing locally.
First, similar to poetry and installing execexam locally we need to do a similar thing with gatorgrade. However, gatorgrade isn't installed with poetry or in the pyproject.toml file so this will look a little different. 
1st - find where gatorgrade is located in order to remove it: command: `which gatorgrade`
2nd - remove this gatorgrade because it is installed from the web: `rm /the/path/to/gatorgrade`
3rd - install the Rebekah's fork of gatorgrade on: [link to the fork](https://github.com/rebekahrudd/gatorgrade)
3.5 - this local version of pipx will be installed using `pipx` so 1st [install pipx](https://www.google.com/search?q=installing+pipx&oq=installing+pipx&gs_lcrp=EgZjaHJvbWUyCQgAEEUYORiABDIHCAEQABiABDIHCAIQABiABDIICAMQABgWGB4yCAgEEAAYFhgeMggIBRAAGBYYHjIICAYQABgWGB4yCAgHEAAYFhgeMggICBAAGBYYHjIICAkQABgWGB7SAQgyNTkxajBqN6gCB7ACAQ&sourceid=chrome&ie=UTF-8)
4th - install the local gatorgrade version: `pipx install /the/path/to/my/package`
5th - enter into your fork of 'executable-examination-example-starter/exam'
6th - poetry install and then run `gatorgrade`
7th - every change you make to gatorgrade you have to reinstall to see the code changes. I just used `pipx install /the/path/to/gatorgrade/ --force`
