### PR TITLE
Progress Bar Implementation

### DIFF
--- a/gatorgrade/main.py
+++ b/gatorgrade/main.py
@@ -46,11 +46,13 @@ def gatorgrade(
             4. use 'env md GITHUB_STEP_SUMMARY' to create GitHub job summary in GitHub Action",
     ),
     run_status_bar: bool = typer.Option(
-        False, "--run_status_bar", help="Enable a progress bar for checks running/not running."
+        False,
+        "--run_status_bar",
+        help="Enable a progress bar for checks running/not running.",
     ),
     no_status_bar: bool = typer.Option(
         False, "--no_status_bar", help="Disable the progress bar entirely."
-    )
+    ),
 ):
     """Run the GatorGrader checks in the specified gatorgrade.yml file."""
     # if ctx.subcommand is None then this means

--- a/gatorgrade/main.py
+++ b/gatorgrade/main.py
@@ -45,6 +45,12 @@ def gatorgrade(
             3. the name of the file or environment variable\
             4. use 'env md GITHUB_STEP_SUMMARY' to create GitHub job summary in GitHub Action",
     ),
+    run_status_bar: bool = typer.Option(
+        False, "--run_status_bar", help="Enable a progress bar for checks running/not running."
+    ),
+    no_status_bar: bool = typer.Option(
+        False, "--no_status_bar", help="Disable the progress bar entirely."
+    )
 ):
     """Run the GatorGrader checks in the specified gatorgrade.yml file."""
     # if ctx.subcommand is None then this means
@@ -55,7 +61,7 @@ def gatorgrade(
         # there are valid checks and thus the
         # tool should run them with run_checks
         if len(checks) > 0:
-            checks_status = run_checks(checks, report)
+            checks_status = run_checks(checks, report, run_status_bar, no_status_bar)
         # no checks were created and this means
         # that, most likely, the file was not
         # valid and thus the tool cannot run checks

--- a/gatorgrade/output/output.py
+++ b/gatorgrade/output/output.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import List
 from typing import Tuple
 from typing import Union
+from rich.progress import Progress, BarColumn, TextColumn
 
 import gator
 import rich
@@ -285,7 +286,7 @@ def write_json_or_md_file(file_name, content_type, content):
 
 
 def run_checks(
-    checks: List[Union[ShellCheck, GatorGraderCheck]], report: Tuple[str, str, str]
+    checks: List[Union[ShellCheck, GatorGraderCheck]], report: Tuple[str, str, str], running_mode=False, no_status_bar=False
 ) -> bool:
     """Run shell and GatorGrader checks and display whether each has passed or failed.
 
@@ -294,44 +295,96 @@ def run_checks(
 
     Args:
         checks: The list of shell and GatorGrader checks to run.
+        running_mode: Convert the Progress Bar to update based on checks ran/not ran.
+        no_status_bar: Option to completely disable all Progress Bar options.
     """
     results = []
     # run each of the checks
-    for check in checks:
-        result = None
-        command_ran = None
-        # run a shell check; this means
-        # that it is going to run a command
-        # in the shell as a part of a check;
-        # store the command that ran in the
-        # field called run_command that is
-        # inside of a CheckResult object but
-        # not initialized in the constructor
-        if isinstance(check, ShellCheck):
-            result = _run_shell_check(check)
-            command_ran = check.command
-            result.run_command = command_ran
-        # run a check that GatorGrader implements
-        elif isinstance(check, GatorGraderCheck):
-            result = _run_gg_check(check)
-            # check to see if there was a command in the
-            # GatorGraderCheck. This code finds the index of the
-            # word "--command" in the check.gg_args list if it
-            # is available (it is not available for all of
-            # the various types of GatorGraderCheck instances),
-            # and then it adds 1 to that index to get the actual
-            # command run and then stores that command in the
-            # result.run_command field that is initialized to
-            # an empty string in the constructor for CheckResult
-            if "--command" in check.gg_args:
-                index_of_command = check.gg_args.index("--command")
-                index_of_new_command = int(index_of_command) + 1
-                result.run_command = check.gg_args[index_of_new_command]
-        # there were results from running checks
-        # and thus they must be displayed
-        if result is not None:
-            result.print()
-            results.append(result)
+    # check how many tests are being ran
+    total_checks = len(checks)
+    # run checks with no progress bar
+    if no_status_bar:
+        for check in checks:
+            result = None
+            command_ran = None
+            # run a shell check; this means
+            # that it is going to run a command
+            # in the shell as a part of a check;
+            # store the command that ran in the
+            # field called run_command that is
+            # inside of a CheckResult object but
+            # not initialized in the constructor
+            if isinstance(check, ShellCheck):
+                result = _run_shell_check(check)
+                command_ran = check.command
+                result.run_command = command_ran
+            # run a check that GatorGrader implements
+            elif isinstance(check, GatorGraderCheck):
+                result = _run_gg_check(check)
+                # check to see if there was a command in the
+                # GatorGraderCheck. This code finds the index of the
+                # word "--command" in the check.gg_args list if it
+                # is available (it is not available for all of
+                # the various types of GatorGraderCheck instances),
+                # and then it adds 1 to that index to get the actual
+                # command run and then stores that command in the
+                # result.run_command field that is initialized to
+                # an empty string in the constructor for CheckResult
+                if "--command" in check.gg_args:
+                    index_of_command = check.gg_args.index("--command")
+                    index_of_new_command = int(index_of_command) + 1
+                    result.run_command = check.gg_args[index_of_new_command]
+            # there were results from running checks
+            # and thus they must be displayed
+            if result is not None:
+                result.print()
+                results.append(result)
+    else:
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(bar_width=40, style="red", complete_style="green", finished_style="green"),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        ) as progress:
+            # add a progress task for tracking
+            task = progress.add_task("[green]Running checks...", total=total_checks)
+            
+            # run each of the checks
+            for check in checks:
+                result = None
+                command_ran = None
+
+                if isinstance(check, ShellCheck):
+                    result = _run_shell_check(check)
+                    command_ran = check.command
+                    result.run_command = command_ran
+                # run a check that GatorGrader implements
+                elif isinstance(check, GatorGraderCheck):
+                    result = _run_gg_check(check)
+                    # check to see if there was a command in the
+                    # GatorGraderCheck. This code finds the index of the
+                    # word "--command" in the check.gg_args list if it
+                    # is available (it is not available for all of
+                    # the various types of GatorGraderCheck instances),
+                    # and then it adds 1 to that index to get the actual
+                    # command run and then stores that command in the
+                    # result.run_command field that is initialized to
+                    # an empty string in the constructor for CheckResult
+                    if "--command" in check.gg_args:
+                        index_of_command = check.gg_args.index("--command")
+                        index_of_new_command = int(index_of_command) + 1
+                        result.run_command = check.gg_args[index_of_new_command]
+                # there were results from running checks
+                # and thus they must be displayed
+                if result is not None:
+                    result.print()
+                    results.append(result)
+                
+                #update progress based on running_mode
+                if running_mode:
+                    progress.update(task, advance=1)
+                else:
+                    if result and result.passed:
+                        progress.update(task, advance=1)
     # determine if there are failures and then display them
     failed_results = list(filter(lambda result: not result.passed, results))
     # print failures list if there are failures to print

--- a/gatorgrade/output/output.py
+++ b/gatorgrade/output/output.py
@@ -8,10 +8,12 @@ from pathlib import Path
 from typing import List
 from typing import Tuple
 from typing import Union
-from rich.progress import Progress, BarColumn, TextColumn
 
 import gator
 import rich
+from rich.progress import BarColumn
+from rich.progress import Progress
+from rich.progress import TextColumn
 
 from gatorgrade.input.checks import GatorGraderCheck
 from gatorgrade.input.checks import ShellCheck
@@ -286,7 +288,10 @@ def write_json_or_md_file(file_name, content_type, content):
 
 
 def run_checks(
-    checks: List[Union[ShellCheck, GatorGraderCheck]], report: Tuple[str, str, str], running_mode=False, no_status_bar=False
+    checks: List[Union[ShellCheck, GatorGraderCheck]],
+    report: Tuple[str, str, str],
+    running_mode=False,
+    no_status_bar=False,
 ) -> bool:
     """Run shell and GatorGrader checks and display whether each has passed or failed.
 
@@ -342,12 +347,17 @@ def run_checks(
     else:
         with Progress(
             TextColumn("[progress.description]{task.description}"),
-            BarColumn(bar_width=40, style="red", complete_style="green", finished_style="green"),
+            BarColumn(
+                bar_width=40,
+                style="red",
+                complete_style="green",
+                finished_style="green",
+            ),
             TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
         ) as progress:
             # add a progress task for tracking
             task = progress.add_task("[green]Running checks...", total=total_checks)
-            
+
             # run each of the checks
             for check in checks:
                 result = None
@@ -378,8 +388,8 @@ def run_checks(
                 if result is not None:
                     result.print()
                     results.append(result)
-                
-                #update progress based on running_mode
+
+                # update progress based on running_mode
                 if running_mode:
                     progress.update(task, advance=1)
                 else:


### PR DESCRIPTION
# Progress Bar Implementation

## Description

This PR introduced a progress bar into the `gatorgrade` that demonstrates some dynamic progress bar to the user. The base implementation -what is included when you run the command `gatorgrade` in your terminal- is a dynamic progress bar that updates a progress bar based on if a check passes or fails, while the checks are being run. If a check passes, the progress updates the green section of the bar and any failed checks remain red on the progress bar. Below is an image of the expected output for the `gatorgrade` command, where as you can see some checks failed so that is represented in the progress bar:

![image](https://github.com/user-attachments/assets/d379ab1a-51d7-4d15-a35e-230fe49d4953)

This is what the progress bar output should look like if all the checks pass:

![image](https://github.com/user-attachments/assets/1a7e42a1-1489-47f6-8dcc-6bf17916e335)


If you run `gatorgrade --run_status_bar` the functionality of the progress bar changes. Instead of updating the dynamic progress bar based on whether the checks pass or fail, this progress bar updates dynamically based on whether a `gatorgrade` check runs or fails to run. This implementation is useful for debugging and more advanced uses of `gatorgrade`. Similarly to the default progress bar, the bar updates green if a check runs and any failed checks keep a section of the bar red. Below is an image of the expected output for the `gatorgrade --run_status_bar` command, where as you can see some checks failed, however this progress bar is only concerned on if the checks run or not:

![image](https://github.com/user-attachments/assets/8cfebbf4-d2c5-40c2-9b5c-8dd2c59f88f7)

Lastly, there is an implementation using the command `gatorgrade --no_status_bar` which disables all progress bars and simply produces the output from `gatorgrade` with no progress bar present. Below is an image of the expected output for the `gatorgrade --no_status_bar` command, where there is no progress bar at all:

![image](https://github.com/user-attachments/assets/7dc42e85-44b3-4da0-aec7-d1f94636070d)

The implementation for this feature are in `output.py` in the `run_checks` functions, and the flags update for `--run_status_bar` and `--no_status_bar` are in `main.py`. I have run and tested this on a Windows 11 OS and would love to have another OS review this PR to ensure the feature is compatible across different OS. Thank you!!

## Type of Change

- [X] Feature
- [ ] Bug fix
- [ ] Documentation

## Contributors

- @TitusSmith33
