### PR TITLE
Fix: only get coverage for test files with code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[coverage:report]
+skip_empty = true
+[json]
+show_contexts=True
+pretty_print=True

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,8 @@
 [coverage:report]
 skip_empty = true
+[run]
+relative_files=true
+source=./gatorgrade
 [json]
 show_contexts=True
 pretty_print=True

--- a/coverage.json
+++ b/coverage.json
@@ -1,0 +1,3480 @@
+{
+    "meta": {
+        "format": 3,
+        "version": "7.6.1",
+        "timestamp": "2024-10-29T18:06:55.034126",
+        "branch_coverage": true,
+        "show_contexts": true
+    },
+    "files": {
+        "tests/__init__.py": {
+            "executed_lines": [
+                1
+            ],
+            "summary": {
+                "covered_lines": 0,
+                "num_statements": 0,
+                "percent_covered": 100.0,
+                "percent_covered_display": "100",
+                "missing_lines": 0,
+                "excluded_lines": 0,
+                "num_branches": 0,
+                "num_partial_branches": 0,
+                "covered_branches": 0,
+                "missing_branches": 0
+            },
+            "missing_lines": [],
+            "excluded_lines": [],
+            "contexts": {
+                "1": [
+                    ""
+                ]
+            },
+            "executed_branches": [],
+            "missing_branches": [],
+            "functions": {
+                "": {
+                    "executed_lines": [
+                        1
+                    ],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 0,
+                        "percent_covered": 100.0,
+                        "percent_covered_display": "100",
+                        "missing_lines": 0,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                }
+            },
+            "classes": {
+                "": {
+                    "executed_lines": [
+                        1
+                    ],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 0,
+                        "percent_covered": 100.0,
+                        "percent_covered_display": "100",
+                        "missing_lines": 0,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                }
+            }
+        },
+        "tests/conftest.py": {
+            "executed_lines": [
+                1,
+                3,
+                5,
+                8,
+                9
+            ],
+            "summary": {
+                "covered_lines": 4,
+                "num_statements": 9,
+                "percent_covered": 54.54545454545455,
+                "percent_covered_display": "55",
+                "missing_lines": 5,
+                "excluded_lines": 0,
+                "num_branches": 2,
+                "num_partial_branches": 0,
+                "covered_branches": 2,
+                "missing_branches": 0
+            },
+            "missing_lines": [
+                11,
+                13,
+                14,
+                16,
+                18
+            ],
+            "excluded_lines": [],
+            "contexts": {
+                "1": [
+                    ""
+                ],
+                "3": [
+                    ""
+                ],
+                "5": [
+                    ""
+                ],
+                "8": [
+                    ""
+                ],
+                "9": [
+                    ""
+                ]
+            },
+            "executed_branches": [
+                [
+                    9,
+                    -1
+                ],
+                [
+                    9,
+                    8
+                ]
+            ],
+            "missing_branches": [],
+            "functions": {
+                "chdir": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 4,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 4,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        11,
+                        13,
+                        16,
+                        18
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "chdir.do_change": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 1,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 1,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        14
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "": {
+                    "executed_lines": [
+                        1,
+                        3,
+                        5,
+                        8,
+                        9
+                    ],
+                    "summary": {
+                        "covered_lines": 4,
+                        "num_statements": 4,
+                        "percent_covered": 100.0,
+                        "percent_covered_display": "100",
+                        "missing_lines": 0,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 2,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [
+                        [
+                            9,
+                            -1
+                        ],
+                        [
+                            9,
+                            8
+                        ]
+                    ],
+                    "missing_branches": []
+                }
+            },
+            "classes": {
+                "": {
+                    "executed_lines": [
+                        1,
+                        3,
+                        5,
+                        8,
+                        9
+                    ],
+                    "summary": {
+                        "covered_lines": 4,
+                        "num_statements": 9,
+                        "percent_covered": 54.54545454545455,
+                        "percent_covered_display": "55",
+                        "missing_lines": 5,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 2,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        11,
+                        13,
+                        14,
+                        16,
+                        18
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [
+                        [
+                            9,
+                            -1
+                        ],
+                        [
+                            9,
+                            8
+                        ]
+                    ],
+                    "missing_branches": []
+                }
+            }
+        },
+        "tests/input/test_input_gg_checks.py": {
+            "executed_lines": [
+                1,
+                3,
+                5,
+                6,
+                7,
+                10,
+                20,
+                43,
+                61,
+                72,
+                88
+            ],
+            "summary": {
+                "covered_lines": 10,
+                "num_statements": 29,
+                "percent_covered": 34.48275862068966,
+                "percent_covered_display": "34",
+                "missing_lines": 19,
+                "excluded_lines": 0,
+                "num_branches": 0,
+                "num_partial_branches": 0,
+                "covered_branches": 0,
+                "missing_branches": 0
+            },
+            "missing_lines": [
+                13,
+                15,
+                17,
+                23,
+                25,
+                27,
+                46,
+                50,
+                52,
+                64,
+                66,
+                68,
+                69,
+                75,
+                77,
+                79,
+                91,
+                93,
+                95
+            ],
+            "excluded_lines": [],
+            "contexts": {
+                "1": [
+                    ""
+                ],
+                "3": [
+                    ""
+                ],
+                "5": [
+                    ""
+                ],
+                "6": [
+                    ""
+                ],
+                "7": [
+                    ""
+                ],
+                "10": [
+                    ""
+                ],
+                "20": [
+                    ""
+                ],
+                "43": [
+                    ""
+                ],
+                "61": [
+                    ""
+                ],
+                "72": [
+                    ""
+                ],
+                "88": [
+                    ""
+                ]
+            },
+            "executed_branches": [],
+            "missing_branches": [],
+            "functions": {
+                "test_parse_config_gg_check_in_file_context_contains_file": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 3,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 3,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        13,
+                        15,
+                        17
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "7": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "20": [
+                            ""
+                        ],
+                        "43": [
+                            ""
+                        ],
+                        "61": [
+                            ""
+                        ],
+                        "72": [
+                            ""
+                        ],
+                        "88": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_parse_config_check_gg_matchfilefragment": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 3,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 3,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        23,
+                        25,
+                        27
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "7": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "20": [
+                            ""
+                        ],
+                        "43": [
+                            ""
+                        ],
+                        "61": [
+                            ""
+                        ],
+                        "72": [
+                            ""
+                        ],
+                        "88": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_parse_config_gg_check_no_file_context_contains_no_file": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 3,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 3,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        46,
+                        50,
+                        52
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "7": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "20": [
+                            ""
+                        ],
+                        "43": [
+                            ""
+                        ],
+                        "61": [
+                            ""
+                        ],
+                        "72": [
+                            ""
+                        ],
+                        "88": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_parse_config_parses_both_shell_and_gg_checks": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 4,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 4,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        64,
+                        66,
+                        68,
+                        69
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "7": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "20": [
+                            ""
+                        ],
+                        "43": [
+                            ""
+                        ],
+                        "61": [
+                            ""
+                        ],
+                        "72": [
+                            ""
+                        ],
+                        "88": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_parse_config_yml_file_runs_setup_shell_checks": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 3,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 3,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        75,
+                        77,
+                        79
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "7": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "20": [
+                            ""
+                        ],
+                        "43": [
+                            ""
+                        ],
+                        "61": [
+                            ""
+                        ],
+                        "72": [
+                            ""
+                        ],
+                        "88": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_parse_config_shell_check_contains_command": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 3,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 3,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        91,
+                        93,
+                        95
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "7": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "20": [
+                            ""
+                        ],
+                        "43": [
+                            ""
+                        ],
+                        "61": [
+                            ""
+                        ],
+                        "72": [
+                            ""
+                        ],
+                        "88": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "": {
+                    "executed_lines": [
+                        1,
+                        3,
+                        5,
+                        6,
+                        7,
+                        10,
+                        20,
+                        43,
+                        61,
+                        72,
+                        88
+                    ],
+                    "summary": {
+                        "covered_lines": 10,
+                        "num_statements": 10,
+                        "percent_covered": 100.0,
+                        "percent_covered_display": "100",
+                        "missing_lines": 0,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "7": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "20": [
+                            ""
+                        ],
+                        "43": [
+                            ""
+                        ],
+                        "61": [
+                            ""
+                        ],
+                        "72": [
+                            ""
+                        ],
+                        "88": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                }
+            },
+            "classes": {
+                "": {
+                    "executed_lines": [
+                        1,
+                        3,
+                        5,
+                        6,
+                        7,
+                        10,
+                        20,
+                        43,
+                        61,
+                        72,
+                        88
+                    ],
+                    "summary": {
+                        "covered_lines": 10,
+                        "num_statements": 29,
+                        "percent_covered": 34.48275862068966,
+                        "percent_covered_display": "34",
+                        "missing_lines": 19,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        13,
+                        15,
+                        17,
+                        23,
+                        25,
+                        27,
+                        46,
+                        50,
+                        52,
+                        64,
+                        66,
+                        68,
+                        69,
+                        75,
+                        77,
+                        79,
+                        91,
+                        93,
+                        95
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "7": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "20": [
+                            ""
+                        ],
+                        "43": [
+                            ""
+                        ],
+                        "61": [
+                            ""
+                        ],
+                        "72": [
+                            ""
+                        ],
+                        "88": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                }
+            }
+        },
+        "tests/output/test_output.py": {
+            "executed_lines": [
+                1,
+                3,
+                4,
+                6,
+                8,
+                9,
+                10
+            ],
+            "summary": {
+                "covered_lines": 6,
+                "num_statements": 59,
+                "percent_covered": 8.955223880597014,
+                "percent_covered_display": "9",
+                "missing_lines": 53,
+                "excluded_lines": 0,
+                "num_branches": 8,
+                "num_partial_branches": 0,
+                "covered_branches": 0,
+                "missing_branches": 8
+            },
+            "missing_lines": [
+                12,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20,
+                22,
+                25,
+                28,
+                41,
+                43,
+                46,
+                47,
+                48,
+                49,
+                52,
+                55,
+                91,
+                93,
+                96,
+                97,
+                100,
+                103,
+                139,
+                141,
+                143,
+                144,
+                147,
+                150,
+                209,
+                210,
+                212,
+                214,
+                215,
+                216,
+                218,
+                220,
+                223,
+                225,
+                279,
+                280,
+                281,
+                284,
+                286,
+                340,
+                341,
+                342,
+                345,
+                347,
+                348,
+                349,
+                350
+            ],
+            "excluded_lines": [],
+            "contexts": {
+                "1": [
+                    ""
+                ],
+                "3": [
+                    ""
+                ],
+                "4": [
+                    ""
+                ],
+                "6": [
+                    ""
+                ],
+                "8": [
+                    ""
+                ],
+                "9": [
+                    ""
+                ],
+                "10": [
+                    ""
+                ]
+            },
+            "executed_branches": [],
+            "missing_branches": [
+                [
+                    16,
+                    15
+                ],
+                [
+                    16,
+                    25
+                ],
+                [
+                    19,
+                    -17
+                ],
+                [
+                    19,
+                    18
+                ],
+                [
+                    280,
+                    -223
+                ],
+                [
+                    280,
+                    281
+                ],
+                [
+                    341,
+                    -284
+                ],
+                [
+                    341,
+                    342
+                ]
+            ],
+            "functions": {
+                "patch_datetime_now": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 4,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 4,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 2
+                    },
+                    "missing_lines": [
+                        17,
+                        18,
+                        19,
+                        22
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            19,
+                            -17
+                        ],
+                        [
+                            19,
+                            18
+                        ]
+                    ]
+                },
+                "patch_datetime_now.mydatetime.now": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 1,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 1,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        20
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_run_checks_invalid_gg_args_prints_exception": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 7,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 7,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        28,
+                        41,
+                        43,
+                        46,
+                        47,
+                        48,
+                        49
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_run_checks_some_failed_prints_correct_summary": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 5,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 5,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        55,
+                        91,
+                        93,
+                        96,
+                        97
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_run_checks_all_passed_prints_correct_summary": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 5,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 5,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        103,
+                        139,
+                        141,
+                        143,
+                        144
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_md_report_file_created_correctly": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 9,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 9,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        150,
+                        209,
+                        210,
+                        212,
+                        214,
+                        215,
+                        216,
+                        218,
+                        220
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_print_error_with_invalid_report_path": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 4,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 4,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 2
+                    },
+                    "missing_lines": [
+                        225,
+                        279,
+                        280,
+                        281
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            280,
+                            -223
+                        ],
+                        [
+                            280,
+                            281
+                        ]
+                    ]
+                },
+                "test_throw_errors_if_report_type_not_md_nor_json": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 4,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 4,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 2
+                    },
+                    "missing_lines": [
+                        286,
+                        340,
+                        341,
+                        342
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            341,
+                            -284
+                        ],
+                        [
+                            341,
+                            342
+                        ]
+                    ]
+                },
+                "test_write_md_and_json_correctly": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 4,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 4,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        347,
+                        348,
+                        349,
+                        350
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "": {
+                    "executed_lines": [
+                        1,
+                        3,
+                        4,
+                        6,
+                        8,
+                        9,
+                        10
+                    ],
+                    "summary": {
+                        "covered_lines": 6,
+                        "num_statements": 16,
+                        "percent_covered": 33.333333333333336,
+                        "percent_covered_display": "33",
+                        "missing_lines": 10,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 2
+                    },
+                    "missing_lines": [
+                        12,
+                        15,
+                        16,
+                        25,
+                        52,
+                        100,
+                        147,
+                        223,
+                        284,
+                        345
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            16,
+                            15
+                        ],
+                        [
+                            16,
+                            25
+                        ]
+                    ]
+                }
+            },
+            "classes": {
+                "patch_datetime_now.mydatetime": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 1,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 1,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        20
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "": {
+                    "executed_lines": [
+                        1,
+                        3,
+                        4,
+                        6,
+                        8,
+                        9,
+                        10
+                    ],
+                    "summary": {
+                        "covered_lines": 6,
+                        "num_statements": 58,
+                        "percent_covered": 9.090909090909092,
+                        "percent_covered_display": "9",
+                        "missing_lines": 52,
+                        "excluded_lines": 0,
+                        "num_branches": 8,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 8
+                    },
+                    "missing_lines": [
+                        12,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        22,
+                        25,
+                        28,
+                        41,
+                        43,
+                        46,
+                        47,
+                        48,
+                        49,
+                        52,
+                        55,
+                        91,
+                        93,
+                        96,
+                        97,
+                        100,
+                        103,
+                        139,
+                        141,
+                        143,
+                        144,
+                        147,
+                        150,
+                        209,
+                        210,
+                        212,
+                        214,
+                        215,
+                        216,
+                        218,
+                        220,
+                        223,
+                        225,
+                        279,
+                        280,
+                        281,
+                        284,
+                        286,
+                        340,
+                        341,
+                        342,
+                        345,
+                        347,
+                        348,
+                        349,
+                        350
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            16,
+                            15
+                        ],
+                        [
+                            16,
+                            25
+                        ],
+                        [
+                            19,
+                            -17
+                        ],
+                        [
+                            19,
+                            18
+                        ],
+                        [
+                            280,
+                            -223
+                        ],
+                        [
+                            280,
+                            281
+                        ],
+                        [
+                            341,
+                            -284
+                        ],
+                        [
+                            341,
+                            342
+                        ]
+                    ]
+                }
+            }
+        },
+        "tests/test_generate.py": {
+            "executed_lines": [
+                1,
+                3,
+                4,
+                6,
+                9,
+                41,
+                92,
+                134
+            ],
+            "summary": {
+                "covered_lines": 7,
+                "num_statements": 96,
+                "percent_covered": 7.142857142857143,
+                "percent_covered_display": "7",
+                "missing_lines": 89,
+                "excluded_lines": 0,
+                "num_branches": 2,
+                "num_partial_branches": 0,
+                "covered_branches": 0,
+                "missing_branches": 2
+            },
+            "missing_lines": [
+                13,
+                14,
+                16,
+                17,
+                19,
+                20,
+                22,
+                23,
+                25,
+                26,
+                28,
+                29,
+                30,
+                31,
+                34,
+                37,
+                38,
+                48,
+                49,
+                51,
+                52,
+                54,
+                55,
+                57,
+                58,
+                60,
+                61,
+                62,
+                63,
+                65,
+                66,
+                67,
+                68,
+                70,
+                71,
+                72,
+                73,
+                75,
+                76,
+                79,
+                82,
+                83,
+                85,
+                86,
+                87,
+                88,
+                89,
+                100,
+                101,
+                103,
+                104,
+                106,
+                107,
+                109,
+                110,
+                112,
+                113,
+                115,
+                116,
+                117,
+                118,
+                122,
+                125,
+                126,
+                127,
+                129,
+                130,
+                131,
+                141,
+                142,
+                144,
+                145,
+                147,
+                148,
+                149,
+                150,
+                152,
+                153,
+                155,
+                156,
+                157,
+                158,
+                163,
+                164,
+                166,
+                169,
+                170,
+                171,
+                172
+            ],
+            "excluded_lines": [],
+            "contexts": {
+                "1": [
+                    ""
+                ],
+                "3": [
+                    ""
+                ],
+                "4": [
+                    ""
+                ],
+                "6": [
+                    ""
+                ],
+                "9": [
+                    ""
+                ],
+                "41": [
+                    ""
+                ],
+                "92": [
+                    ""
+                ],
+                "134": [
+                    ""
+                ]
+            },
+            "executed_branches": [],
+            "missing_branches": [
+                [
+                    163,
+                    164
+                ],
+                [
+                    163,
+                    166
+                ]
+            ],
+            "functions": {
+                "test_generate_should_create_gatorgrade_yml_file": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 17,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 17,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        13,
+                        14,
+                        16,
+                        17,
+                        19,
+                        20,
+                        22,
+                        23,
+                        25,
+                        26,
+                        28,
+                        29,
+                        30,
+                        31,
+                        34,
+                        37,
+                        38
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "41": [
+                            ""
+                        ],
+                        "92": [
+                            ""
+                        ],
+                        "134": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_generated_gatorgrade_yml_file_should_contain_correct_paths_when_successfully_ran": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 30,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 30,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        48,
+                        49,
+                        51,
+                        52,
+                        54,
+                        55,
+                        57,
+                        58,
+                        60,
+                        61,
+                        62,
+                        63,
+                        65,
+                        66,
+                        67,
+                        68,
+                        70,
+                        71,
+                        72,
+                        73,
+                        75,
+                        76,
+                        79,
+                        82,
+                        83,
+                        85,
+                        86,
+                        87,
+                        88,
+                        89
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "41": [
+                            ""
+                        ],
+                        "92": [
+                            ""
+                        ],
+                        "134": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_generate_should_produce_warning_message_when_some_user_inputted_files_dont_exist": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 21,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 21,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        100,
+                        101,
+                        103,
+                        104,
+                        106,
+                        107,
+                        109,
+                        110,
+                        112,
+                        113,
+                        115,
+                        116,
+                        117,
+                        118,
+                        122,
+                        125,
+                        126,
+                        127,
+                        129,
+                        130,
+                        131
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "41": [
+                            ""
+                        ],
+                        "92": [
+                            ""
+                        ],
+                        "134": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_generate_should_throw_an_error_when_none_of_user_provided_files_exist": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 21,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 21,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 2
+                    },
+                    "missing_lines": [
+                        141,
+                        142,
+                        144,
+                        145,
+                        147,
+                        148,
+                        149,
+                        150,
+                        152,
+                        153,
+                        155,
+                        156,
+                        157,
+                        158,
+                        163,
+                        164,
+                        166,
+                        169,
+                        170,
+                        171,
+                        172
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "41": [
+                            ""
+                        ],
+                        "92": [
+                            ""
+                        ],
+                        "134": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            163,
+                            164
+                        ],
+                        [
+                            163,
+                            166
+                        ]
+                    ]
+                },
+                "": {
+                    "executed_lines": [
+                        1,
+                        3,
+                        4,
+                        6,
+                        9,
+                        41,
+                        92,
+                        134
+                    ],
+                    "summary": {
+                        "covered_lines": 7,
+                        "num_statements": 7,
+                        "percent_covered": 100.0,
+                        "percent_covered_display": "100",
+                        "missing_lines": 0,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "41": [
+                            ""
+                        ],
+                        "92": [
+                            ""
+                        ],
+                        "134": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                }
+            },
+            "classes": {
+                "": {
+                    "executed_lines": [
+                        1,
+                        3,
+                        4,
+                        6,
+                        9,
+                        41,
+                        92,
+                        134
+                    ],
+                    "summary": {
+                        "covered_lines": 7,
+                        "num_statements": 96,
+                        "percent_covered": 7.142857142857143,
+                        "percent_covered_display": "7",
+                        "missing_lines": 89,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 2
+                    },
+                    "missing_lines": [
+                        13,
+                        14,
+                        16,
+                        17,
+                        19,
+                        20,
+                        22,
+                        23,
+                        25,
+                        26,
+                        28,
+                        29,
+                        30,
+                        31,
+                        34,
+                        37,
+                        38,
+                        48,
+                        49,
+                        51,
+                        52,
+                        54,
+                        55,
+                        57,
+                        58,
+                        60,
+                        61,
+                        62,
+                        63,
+                        65,
+                        66,
+                        67,
+                        68,
+                        70,
+                        71,
+                        72,
+                        73,
+                        75,
+                        76,
+                        79,
+                        82,
+                        83,
+                        85,
+                        86,
+                        87,
+                        88,
+                        89,
+                        100,
+                        101,
+                        103,
+                        104,
+                        106,
+                        107,
+                        109,
+                        110,
+                        112,
+                        113,
+                        115,
+                        116,
+                        117,
+                        118,
+                        122,
+                        125,
+                        126,
+                        127,
+                        129,
+                        130,
+                        131,
+                        141,
+                        142,
+                        144,
+                        145,
+                        147,
+                        148,
+                        149,
+                        150,
+                        152,
+                        153,
+                        155,
+                        156,
+                        157,
+                        158,
+                        163,
+                        164,
+                        166,
+                        169,
+                        170,
+                        171,
+                        172
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "4": [
+                            ""
+                        ],
+                        "6": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "41": [
+                            ""
+                        ],
+                        "92": [
+                            ""
+                        ],
+                        "134": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            163,
+                            164
+                        ],
+                        [
+                            163,
+                            166
+                        ]
+                    ]
+                }
+            }
+        },
+        "tests/test_generate_success.py": {
+            "executed_lines": [
+                1,
+                3,
+                5,
+                8,
+                9,
+                26,
+                35,
+                44,
+                56
+            ],
+            "summary": {
+                "covered_lines": 8,
+                "num_statements": 30,
+                "percent_covered": 31.25,
+                "percent_covered_display": "31",
+                "missing_lines": 22,
+                "excluded_lines": 0,
+                "num_branches": 2,
+                "num_partial_branches": 0,
+                "covered_branches": 2,
+                "missing_branches": 0
+            },
+            "missing_lines": [
+                12,
+                13,
+                15,
+                16,
+                18,
+                19,
+                21,
+                22,
+                23,
+                29,
+                31,
+                32,
+                38,
+                40,
+                41,
+                49,
+                51,
+                52,
+                53,
+                59,
+                60,
+                62
+            ],
+            "excluded_lines": [],
+            "contexts": {
+                "1": [
+                    ""
+                ],
+                "3": [
+                    ""
+                ],
+                "5": [
+                    ""
+                ],
+                "8": [
+                    ""
+                ],
+                "9": [
+                    ""
+                ],
+                "26": [
+                    ""
+                ],
+                "35": [
+                    ""
+                ],
+                "44": [
+                    ""
+                ],
+                "56": [
+                    ""
+                ]
+            },
+            "executed_branches": [
+                [
+                    9,
+                    8
+                ],
+                [
+                    9,
+                    26
+                ]
+            ],
+            "missing_branches": [],
+            "functions": {
+                "setup_files": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 9,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 9,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        12,
+                        13,
+                        15,
+                        16,
+                        18,
+                        19,
+                        21,
+                        22,
+                        23
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "26": [
+                            ""
+                        ],
+                        "35": [
+                            ""
+                        ],
+                        "44": [
+                            ""
+                        ],
+                        "56": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_generate_config_create_gatorgrade_yml": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 3,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 3,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        29,
+                        31,
+                        32
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "26": [
+                            ""
+                        ],
+                        "35": [
+                            ""
+                        ],
+                        "44": [
+                            ""
+                        ],
+                        "56": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_generate_config_creates_gatorgrade_yml_with_dir_in_user_input": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 3,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 3,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        38,
+                        40,
+                        41
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "26": [
+                            ""
+                        ],
+                        "35": [
+                            ""
+                        ],
+                        "44": [
+                            ""
+                        ],
+                        "56": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_generate_config_creates_gatorgrade_yml_without_dir_not_in_user_input": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 4,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 4,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        49,
+                        51,
+                        52,
+                        53
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "26": [
+                            ""
+                        ],
+                        "35": [
+                            ""
+                        ],
+                        "44": [
+                            ""
+                        ],
+                        "56": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "test_generate_success_message": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 3,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 3,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        59,
+                        60,
+                        62
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "26": [
+                            ""
+                        ],
+                        "35": [
+                            ""
+                        ],
+                        "44": [
+                            ""
+                        ],
+                        "56": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "": {
+                    "executed_lines": [
+                        1,
+                        3,
+                        5,
+                        8,
+                        9,
+                        26,
+                        35,
+                        44,
+                        56
+                    ],
+                    "summary": {
+                        "covered_lines": 8,
+                        "num_statements": 8,
+                        "percent_covered": 100.0,
+                        "percent_covered_display": "100",
+                        "missing_lines": 0,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 2,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "26": [
+                            ""
+                        ],
+                        "35": [
+                            ""
+                        ],
+                        "44": [
+                            ""
+                        ],
+                        "56": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [
+                        [
+                            9,
+                            8
+                        ],
+                        [
+                            9,
+                            26
+                        ]
+                    ],
+                    "missing_branches": []
+                }
+            },
+            "classes": {
+                "": {
+                    "executed_lines": [
+                        1,
+                        3,
+                        5,
+                        8,
+                        9,
+                        26,
+                        35,
+                        44,
+                        56
+                    ],
+                    "summary": {
+                        "covered_lines": 8,
+                        "num_statements": 30,
+                        "percent_covered": 31.25,
+                        "percent_covered_display": "31",
+                        "missing_lines": 22,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 2,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        12,
+                        13,
+                        15,
+                        16,
+                        18,
+                        19,
+                        21,
+                        22,
+                        23,
+                        29,
+                        31,
+                        32,
+                        38,
+                        40,
+                        41,
+                        49,
+                        51,
+                        52,
+                        53,
+                        59,
+                        60,
+                        62
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "3": [
+                            ""
+                        ],
+                        "5": [
+                            ""
+                        ],
+                        "8": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "26": [
+                            ""
+                        ],
+                        "35": [
+                            ""
+                        ],
+                        "44": [
+                            ""
+                        ],
+                        "56": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [
+                        [
+                            9,
+                            8
+                        ],
+                        [
+                            9,
+                            26
+                        ]
+                    ],
+                    "missing_branches": []
+                }
+            }
+        },
+        "tests/test_main.py": {
+            "executed_lines": [
+                1,
+                9,
+                10,
+                11,
+                13,
+                14,
+                16
+            ],
+            "summary": {
+                "covered_lines": 6,
+                "num_statements": 29,
+                "percent_covered": 15.384615384615385,
+                "percent_covered_display": "15",
+                "missing_lines": 23,
+                "excluded_lines": 0,
+                "num_branches": 10,
+                "num_partial_branches": 0,
+                "covered_branches": 0,
+                "missing_branches": 10
+            },
+            "missing_lines": [
+                18,
+                21,
+                24,
+                34,
+                35,
+                36,
+                47,
+                50,
+                51,
+                53,
+                54,
+                55,
+                56,
+                57,
+                58,
+                82,
+                97,
+                103,
+                111,
+                113,
+                115,
+                116,
+                117
+            ],
+            "excluded_lines": [],
+            "contexts": {
+                "1": [
+                    ""
+                ],
+                "9": [
+                    ""
+                ],
+                "10": [
+                    ""
+                ],
+                "11": [
+                    ""
+                ],
+                "13": [
+                    ""
+                ],
+                "14": [
+                    ""
+                ],
+                "16": [
+                    ""
+                ]
+            },
+            "executed_branches": [],
+            "missing_branches": [
+                [
+                    34,
+                    35
+                ],
+                [
+                    34,
+                    36
+                ],
+                [
+                    51,
+                    50
+                ],
+                [
+                    51,
+                    82
+                ],
+                [
+                    57,
+                    -50
+                ],
+                [
+                    57,
+                    58
+                ],
+                [
+                    97,
+                    -1
+                ],
+                [
+                    97,
+                    82
+                ],
+                [
+                    116,
+                    -82
+                ],
+                [
+                    116,
+                    117
+                ]
+            ],
+            "functions": {
+                "patch_open": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 2,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 2,
+                        "excluded_lines": 0,
+                        "num_branches": 0,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 0
+                    },
+                    "missing_lines": [
+                        24,
+                        47
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "11": [
+                            ""
+                        ],
+                        "13": [
+                            ""
+                        ],
+                        "14": [
+                            ""
+                        ],
+                        "16": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": []
+                },
+                "patch_open.open_patched": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 3,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 3,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 2
+                    },
+                    "missing_lines": [
+                        34,
+                        35,
+                        36
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "11": [
+                            ""
+                        ],
+                        "13": [
+                            ""
+                        ],
+                        "14": [
+                            ""
+                        ],
+                        "16": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            34,
+                            35
+                        ],
+                        [
+                            34,
+                            36
+                        ]
+                    ]
+                },
+                "cleanup_files": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 6,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 6,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 2
+                    },
+                    "missing_lines": [
+                        53,
+                        54,
+                        55,
+                        56,
+                        57,
+                        58
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "11": [
+                            ""
+                        ],
+                        "13": [
+                            ""
+                        ],
+                        "14": [
+                            ""
+                        ],
+                        "16": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            57,
+                            -50
+                        ],
+                        [
+                            57,
+                            58
+                        ]
+                    ]
+                },
+                "test_full_integration_creates_valid_output": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 6,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 6,
+                        "excluded_lines": 0,
+                        "num_branches": 2,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 2
+                    },
+                    "missing_lines": [
+                        103,
+                        111,
+                        113,
+                        115,
+                        116,
+                        117
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "11": [
+                            ""
+                        ],
+                        "13": [
+                            ""
+                        ],
+                        "14": [
+                            ""
+                        ],
+                        "16": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            116,
+                            -82
+                        ],
+                        [
+                            116,
+                            117
+                        ]
+                    ]
+                },
+                "": {
+                    "executed_lines": [
+                        1,
+                        9,
+                        10,
+                        11,
+                        13,
+                        14,
+                        16
+                    ],
+                    "summary": {
+                        "covered_lines": 6,
+                        "num_statements": 12,
+                        "percent_covered": 37.5,
+                        "percent_covered_display": "38",
+                        "missing_lines": 6,
+                        "excluded_lines": 0,
+                        "num_branches": 4,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 4
+                    },
+                    "missing_lines": [
+                        18,
+                        21,
+                        50,
+                        51,
+                        82,
+                        97
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "11": [
+                            ""
+                        ],
+                        "13": [
+                            ""
+                        ],
+                        "14": [
+                            ""
+                        ],
+                        "16": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            51,
+                            50
+                        ],
+                        [
+                            51,
+                            82
+                        ],
+                        [
+                            97,
+                            -1
+                        ],
+                        [
+                            97,
+                            82
+                        ]
+                    ]
+                }
+            },
+            "classes": {
+                "": {
+                    "executed_lines": [
+                        1,
+                        9,
+                        10,
+                        11,
+                        13,
+                        14,
+                        16
+                    ],
+                    "summary": {
+                        "covered_lines": 6,
+                        "num_statements": 29,
+                        "percent_covered": 15.384615384615385,
+                        "percent_covered_display": "15",
+                        "missing_lines": 23,
+                        "excluded_lines": 0,
+                        "num_branches": 10,
+                        "num_partial_branches": 0,
+                        "covered_branches": 0,
+                        "missing_branches": 10
+                    },
+                    "missing_lines": [
+                        18,
+                        21,
+                        24,
+                        34,
+                        35,
+                        36,
+                        47,
+                        50,
+                        51,
+                        53,
+                        54,
+                        55,
+                        56,
+                        57,
+                        58,
+                        82,
+                        97,
+                        103,
+                        111,
+                        113,
+                        115,
+                        116,
+                        117
+                    ],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [
+                            ""
+                        ],
+                        "9": [
+                            ""
+                        ],
+                        "10": [
+                            ""
+                        ],
+                        "11": [
+                            ""
+                        ],
+                        "13": [
+                            ""
+                        ],
+                        "14": [
+                            ""
+                        ],
+                        "16": [
+                            ""
+                        ]
+                    },
+                    "executed_branches": [],
+                    "missing_branches": [
+                        [
+                            34,
+                            35
+                        ],
+                        [
+                            34,
+                            36
+                        ],
+                        [
+                            51,
+                            50
+                        ],
+                        [
+                            51,
+                            82
+                        ],
+                        [
+                            57,
+                            -50
+                        ],
+                        [
+                            57,
+                            58
+                        ],
+                        [
+                            97,
+                            -1
+                        ],
+                        [
+                            97,
+                            82
+                        ],
+                        [
+                            116,
+                            -82
+                        ],
+                        [
+                            116,
+                            117
+                        ]
+                    ]
+                }
+            }
+        }
+    },
+    "totals": {
+        "covered_lines": 41,
+        "num_statements": 252,
+        "percent_covered": 16.304347826086957,
+        "percent_covered_display": "16",
+        "missing_lines": 211,
+        "excluded_lines": 0,
+        "num_branches": 24,
+        "num_partial_branches": 0,
+        "covered_branches": 4,
+        "missing_branches": 20
+    }
+}

--- a/coverage.json
+++ b/coverage.json
@@ -2,7 +2,7 @@
     "meta": {
         "format": 3,
         "version": "7.6.1",
-        "timestamp": "2024-10-31T14:55:34.986059",
+        "timestamp": "2024-11-04T10:24:47.095177",
         "branch_coverage": true,
         "show_contexts": true
     },

--- a/coverage.json
+++ b/coverage.json
@@ -2,7 +2,7 @@
     "meta": {
         "format": 3,
         "version": "7.6.1",
-        "timestamp": "2024-10-29T18:06:55.034126",
+        "timestamp": "2024-10-31T14:55:34.986059",
         "branch_coverage": true,
         "show_contexts": true
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ types-pyyaml = "^6.0.12.20240917"
 project = "gatorgrade"
 tests = "tests"
 check-command = { var = "ruff check {project} {tests}", recursive = true }
-coverage-test-command = "pytest -s --cov=tests --cov-context=test --cov-fail-under=50 --cov-report term-missing --cov-report json --cov-branch"
-coverage-test-command-silent = "pytest -x --show-capture=no --cov=tests --cov-report term-missing --cov-report json --cov-branch"
+coverage-test-command = "pytest -s --cov-context=test --cov-fail-under=50 --cov-config .coveragerc --cov-report term-missing --cov --cov-branch"
+coverage-test-command-silent = "pytest -x --show-capture=no --cov-config .coveragerc --cov-report term-missing --cov-report json --cov --cov-branch"
 developer-test-command = "pytest -x -s"
 developer-test-silent-command = "pytest -x --show-capture=no"
 fixformat-command = { var = "ruff format {project} {tests}", recursive = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ types-pyyaml = "^6.0.12.20240917"
 project = "gatorgrade"
 tests = "tests"
 check-command = { var = "ruff check {project} {tests}", recursive = true }
-coverage-test-command = "pytest -s --cov-context=test --cov-fail-under=90 --cov-report term-missing --cov-report json --cov --cov-branch"
-coverage-test-command-silent = "pytest -x --show-capture=no --cov-report term-missing --cov-report json --cov --cov-branch"
+coverage-test-command = "pytest -s --cov=tests --cov-context=test --cov-fail-under=50 --cov-report term-missing --cov-report json --cov-branch"
+coverage-test-command-silent = "pytest -x --show-capture=no --cov=tests --cov-report term-missing --cov-report json --cov-branch"
 developer-test-command = "pytest -x -s"
 developer-test-silent-command = "pytest -x --show-capture=no"
 fixformat-command = { var = "ruff format {project} {tests}", recursive = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ mypy-command = {var = "mypy {project}", recursive = true}
 all = "task lint && task test"
 lint = "task format && task check && task mypy"
 check = { cmd = "{check-command}", help = "Run the ruff linting checks", use_vars = true }
+coverage = { cmd = "{coverage-test-command}", help = "Run test coverage monitoring", use_vars = true }
+coverage-silent = { cmd = "{coverage-test-command-silent}", help = "Run test coverage monitoring", use_vars = true }
 format = { cmd = "{format-command}", help = "Run the ruff formatter on source code", use_vars = true }
 format-fix = { cmd = "{fixformat-command}", help = "Run the ruff formatter to fix source code", use_vars = true }
 mypy = { cmd = "{mypy-command}", help = "Run the mypy type checker for potential type errors", use_vars = true }

--- a/tests/output/test_output.py
+++ b/tests/output/test_output.py
@@ -13,7 +13,7 @@ FAKE_TIME = datetime.datetime(2022, 1, 1, 10, 30, 0)
 
 
 @pytest.fixture
-def patch_datetime_now(monkeypatch):
+def patch_datetime_now(monkeypatch: pytest.MonkeyPatch):
     class mydatetime:
         @classmethod
         def now(cls):
@@ -22,7 +22,7 @@ def patch_datetime_now(monkeypatch):
     monkeypatch.setattr(datetime, "datetime", mydatetime)
 
 
-def test_run_checks_invalid_gg_args_prints_exception(capsys):
+def test_run_checks_invalid_gg_args_prints_exception(capsys: pytest.CaptureFixture[str]):
     """Test that run_checks prints an exception when given an invalid GatorGrader argument."""
     # Given a GatorGrader check with invalid arguments
     check = GatorGraderCheck(
@@ -49,7 +49,7 @@ def test_run_checks_invalid_gg_args_prints_exception(capsys):
     assert "Invalid GatorGrader check:" in out
 
 
-def test_run_checks_some_failed_prints_correct_summary(capsys):
+def test_run_checks_some_failed_prints_correct_summary(capsys: pytest.CaptureFixture[str]):
     """Test that run_checks, when given some checks that should fail, prints the correct summary."""
     # Given three checks with one check that should fail
     checks = [
@@ -97,7 +97,7 @@ def test_run_checks_some_failed_prints_correct_summary(capsys):
     assert "Passed 2/3 (67%) of checks" in out
 
 
-def test_run_checks_all_passed_prints_correct_summary(capsys):
+def test_run_checks_all_passed_prints_correct_summary(capsys: pytest.CaptureFixture[str]):
     """Test that run_checks, when given checks that should all pass, prints the correct summary."""
     # Given three checks that should all pass
     checks = [
@@ -342,7 +342,7 @@ def test_throw_errors_if_report_type_not_md_nor_json():
         output.run_checks(checks, report)
 
 
-def test_write_md_and_json_correctly(tmp_path):
+def test_write_md_and_json_correctly(tmp_path: output.Path):
     """Test process of writing is good for both json and md."""
     tmp_md = tmp_path / "test.md"
     tmp_json = tmp_path / "test.json"


### PR DESCRIPTION
# Fix: only get coverage for test files with code

## Description
This fix adds the .coveragerc to only run the coverage on files with code. It also has a change in the pyproject.toml to make the threshold only need %50 coverage to pass and to only give coverage for the test file. 
There are two commands that need to be checked for different computer systems because different outputs have been seen on linux and MacOS. Have not seen a windows computer try and run this.
For the command ```pytest -s --cov=tests --cov-context=test --cov-fail-under=50 --cov-report term-missing --cov-report json --cov-branch``` This is what was given as the output on linux 
![Screenshot from 2024-10-31 19-49-08](https://github.com/user-attachments/assets/864237c4-7b2a-41ff-8b1e-8b956dcd0426)
Then for the command ```poetry run task test``` This is what was given as the output on linux
![Screenshot from 2024-10-31 19-50-12](https://github.com/user-attachments/assets/0721a1e4-b184-4939-8475-d9e46f127e85)
When you run it can you share a screenshot of the output if it is different.


## Type of Change

- [ ] Feature
- [X] Bug fix
- [ ] Documentation


## Reminder

 - All GitHub Actions should be in a passing state before any pull request is merged.
 - All PRs must be reviewed by at least one team member and one member of the Integration team!
 - Any issues this PR closes are tagged in the description!
