### PR TITLE
feat: defined command output in check_result.py

### DIFF
--- a/gatorgrade/output/check_result.py
+++ b/gatorgrade/output/check_result.py
@@ -44,7 +44,7 @@ class CheckResult:  # pylint: disable=too-few-public-methods
         icon_color = "green" if self.passed else "red"
         message = f"[{icon_color}]{icon}[/]  {self.description}"
         if not self.passed and show_diagnostic:
-            message += f"\n[yellow]   → {self.diagnostic}"
+            message += f"\n[yellow]   → Failing command output: {self.diagnostic}"
         return message
 
     def __repr__(self):

--- a/gatorgrade/output/check_result.py
+++ b/gatorgrade/output/check_result.py
@@ -44,7 +44,7 @@ class CheckResult:  # pylint: disable=too-few-public-methods
         icon_color = "green" if self.passed else "red"
         message = f"[{icon_color}]{icon}[/]  {self.description}"
         if not self.passed and show_diagnostic:
-            message += f"\n[yellow]   → Failing command output: {self.diagnostic}"
+            message += f"\n[blue]   → Failing command output: [green]{self.diagnostic}"
         return message
 
     def __repr__(self):


### PR DESCRIPTION
# Adding a failed output descript tag

## Description
`gatorgrade` uses a tag to define what command ran by saying "Run this command: ", however, the failing lines of code that `gatorgrade` produces are not defined. This update defines the failed output with the line "Failing command output: ".

## Linked Issues
[https://github.com/GatorEducator/gatorgrade/issues/152](https://github.com/GatorEducator/gatorgrade/issues/152)
closes: #152 

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation

## Contributors
- @rebekahrudd 

## Reminder

To check this PR install `gatorgrade` from the `define_failing_output` branch and run it on any repo to test the output.  
This should be the output that you will see:
![failing_output_definition](https://github.com/user-attachments/assets/03a3f2f1-efb1-4f7e-9cc8-28477c867b2b)
