### PR TITLE
Test cases for check_result.py

### DIFF
--- a/tests/output/test_check_result.py
+++ b/tests/output/test_check_result.py
@@ -1,0 +1,106 @@
+import unittest
+from typing import Union
+from io import StringIO
+from unittest.mock import patch
+import rich
+# from your_module import CheckResult  # Replace 'your_module' with the actual module name where CheckResult is defined.
+from gatorgrade.output.check_result import CheckResult
+
+
+class TestCheckResult(unittest.TestCase):
+
+    def test_initialization(self):
+        """Test if the CheckResult object is correctly initialized."""
+        check = CheckResult(
+            passed=True,
+            description="Check passed successfully",
+            json_info={"key": "value"},
+            path="test/path",
+            diagnostic="All tests passed"
+        )
+
+        self.assertEqual(check.passed, True)
+        self.assertEqual(check.description, "Check passed successfully")
+        self.assertEqual(check.json_info, {"key": "value"})
+        self.assertEqual(check.path, "test/path")
+        self.assertEqual(check.diagnostic, "All tests passed")
+
+    def test_default_diagnostic_message(self):
+        """Test if default diagnostic message is used when not provided."""
+        check = CheckResult(
+            passed=False,
+            description="Check failed",
+            json_info={"key": "value"}
+        )
+
+        self.assertEqual(check.diagnostic, "No diagnostic message available")
+
+    def test_display_result_passed(self):
+        """Test the display_result method when the check has passed."""
+        check = CheckResult(
+            passed=True,
+            description="Check passed successfully",
+            json_info={"key": "value"}
+        )
+
+        expected_output = "[green]✓[/]  Check passed successfully"
+        self.assertEqual(check.display_result(), expected_output)
+
+    def test_display_result_failed_no_diagnostic(self):
+        """Test the display_result method when the check has failed and no diagnostic is shown."""
+        check = CheckResult(
+            passed=False,
+            description="Check failed",
+            json_info={"key": "value"}
+        )
+
+        expected_output = "[red]✕[/]  Check failed"
+        self.assertEqual(check.display_result(), expected_output)
+
+    def test_display_result_failed_with_diagnostic(self):
+        """Test the display_result method when the check has failed and diagnostic is shown."""
+        check = CheckResult(
+            passed=False,
+            description="Check failed",
+            json_info={"key": "value"},
+            diagnostic="Test failed due to XYZ"
+        )
+
+        expected_output = "[red]✕[/]  Check failed\n[yellow]   → Test failed due to XYZ"
+        self.assertEqual(check.display_result(show_diagnostic=True), expected_output)
+
+    def test_repr(self):
+        """Test the __repr__ method."""
+        check = CheckResult(
+            passed=True,
+            description="Check passed successfully",
+            json_info={"key": "value"},
+            path="test/path",
+            diagnostic="All tests passed"
+        )
+
+        expected_repr = ("CheckResult(passed=True, description='Check passed successfully', "
+                         "json_info={'key': 'value'}, path='test/path', "
+                         "diagnostic='All tests passed', run_command='')")
+        self.assertEqual(repr(check), expected_repr)
+
+    @patch("rich.print")
+    def test_print(self, mock_print):
+        """Test the print method."""
+        check = CheckResult(
+            passed=False,
+            description="Check failed",
+            json_info={"key": "value"},
+            diagnostic="Test failed due to XYZ"
+        )
+
+        # Call the print method, which internally calls rich.print
+        check.print(show_diagnostic=True)
+
+        # Verify if rich.print was called with the expected message
+        expected_message = "[red]✕[/]  Check failed\n[yellow]   → Test failed due to XYZ"
+        mock_print.assert_called_once_with(expected_message)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/output/test_check_result.py
+++ b/tests/output/test_check_result.py
@@ -3,12 +3,12 @@ from typing import Union
 from io import StringIO
 from unittest.mock import patch
 import rich
+
 # from your_module import CheckResult  # Replace 'your_module' with the actual module name where CheckResult is defined.
 from gatorgrade.output.check_result import CheckResult
 
 
 class TestCheckResult(unittest.TestCase):
-
     def test_initialization(self):
         """Test if the CheckResult object is correctly initialized."""
         check = CheckResult(
@@ -16,7 +16,7 @@ class TestCheckResult(unittest.TestCase):
             description="Check passed successfully",
             json_info={"key": "value"},
             path="test/path",
-            diagnostic="All tests passed"
+            diagnostic="All tests passed",
         )
 
         self.assertEqual(check.passed, True)
@@ -28,9 +28,7 @@ class TestCheckResult(unittest.TestCase):
     def test_default_diagnostic_message(self):
         """Test if default diagnostic message is used when not provided."""
         check = CheckResult(
-            passed=False,
-            description="Check failed",
-            json_info={"key": "value"}
+            passed=False, description="Check failed", json_info={"key": "value"}
         )
 
         self.assertEqual(check.diagnostic, "No diagnostic message available")
@@ -40,7 +38,7 @@ class TestCheckResult(unittest.TestCase):
         check = CheckResult(
             passed=True,
             description="Check passed successfully",
-            json_info={"key": "value"}
+            json_info={"key": "value"},
         )
 
         expected_output = "[green]✓[/]  Check passed successfully"
@@ -49,9 +47,7 @@ class TestCheckResult(unittest.TestCase):
     def test_display_result_failed_no_diagnostic(self):
         """Test the display_result method when the check has failed and no diagnostic is shown."""
         check = CheckResult(
-            passed=False,
-            description="Check failed",
-            json_info={"key": "value"}
+            passed=False, description="Check failed", json_info={"key": "value"}
         )
 
         expected_output = "[red]✕[/]  Check failed"
@@ -63,7 +59,7 @@ class TestCheckResult(unittest.TestCase):
             passed=False,
             description="Check failed",
             json_info={"key": "value"},
-            diagnostic="Test failed due to XYZ"
+            diagnostic="Test failed due to XYZ",
         )
 
         expected_output = "[red]✕[/]  Check failed\n[yellow]   → Test failed due to XYZ"
@@ -76,12 +72,14 @@ class TestCheckResult(unittest.TestCase):
             description="Check passed successfully",
             json_info={"key": "value"},
             path="test/path",
-            diagnostic="All tests passed"
+            diagnostic="All tests passed",
         )
 
-        expected_repr = ("CheckResult(passed=True, description='Check passed successfully', "
-                         "json_info={'key': 'value'}, path='test/path', "
-                         "diagnostic='All tests passed', run_command='')")
+        expected_repr = (
+            "CheckResult(passed=True, description='Check passed successfully', "
+            "json_info={'key': 'value'}, path='test/path', "
+            "diagnostic='All tests passed', run_command='')"
+        )
         self.assertEqual(repr(check), expected_repr)
 
     @patch("rich.print")
@@ -91,16 +89,18 @@ class TestCheckResult(unittest.TestCase):
             passed=False,
             description="Check failed",
             json_info={"key": "value"},
-            diagnostic="Test failed due to XYZ"
+            diagnostic="Test failed due to XYZ",
         )
 
         # Call the print method, which internally calls rich.print
         check.print(show_diagnostic=True)
 
         # Verify if rich.print was called with the expected message
-        expected_message = "[red]✕[/]  Check failed\n[yellow]   → Test failed due to XYZ"
+        expected_message = (
+            "[red]✕[/]  Check failed\n[yellow]   → Test failed due to XYZ"
+        )
         mock_print.assert_called_once_with(expected_message)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/output/test_check_result.py
+++ b/tests/output/test_check_result.py
@@ -1,8 +1,7 @@
+"""Test suite for check_result.py."""
+
 import unittest
-from typing import Union
-from io import StringIO
 from unittest.mock import patch
-import rich
 
 # from your_module import CheckResult  # Replace 'your_module' with the actual module name where CheckResult is defined.
 from gatorgrade.output.check_result import CheckResult


### PR DESCRIPTION
# Test cases for check_result.py

## Description

This PR provides test cases written for the check_result.py file. This PR should be checked by entering the `test/check_result` branch and running the command `pytest`. If all tests pass then this PR can be approved.

## Linked Issues
https://github.com/GatorEducator/gatorgrade/issues/162 
closes: #162 

## Type of Change

<!-- TODO: Fill in the brackets with an `x` next to all types that apply to the proposed changes -->
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [x] Testing coverage

## Contributors

<!-- TODO: Add your GitHub username below and the GitHub usernames of all other contributors to the proposed changes -->
- @rebekahrudd 

## Reminder

Here is a terminal view of the test coverage before `test_check_result.py` file:
![s test_cov_before](https://github.com/user-attachments/assets/e74441ba-2c1e-4d87-b76a-784540b6f034)

Here is a terminal view of the test coverage after `test_check_result.py` file:
![ss after_test_cases](https://github.com/user-attachments/assets/ac08e39f-e04d-4c16-8187-5bd7eee163d7)

Here is a terminal view to show all test cases are passing:
![ss pytest passing](https://github.com/user-attachments/assets/36c31d35-5f4b-443e-9502-6ba19fe0a25f)