### PR TITLE
feat: Report skip reasons when loading history reports

### DIFF
--- a/gatorgrade/report_history.py
+++ b/gatorgrade/report_history.py
@@ -7,7 +7,7 @@ import json
 import os
 import uuid
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Sequence, cast
 
 import platformdirs
 
@@ -278,8 +278,8 @@ def load_history_reports_with_diagnostics(
             reports.append(payload)
             if maximum_reports is not None and len(reports) >= maximum_reports:
                 break
-        elif reason is not None:
-            diagnostics.append((path, reason))
+        else:
+            diagnostics.append((path, cast(str, reason)))
     return reports, diagnostics
 
 

--- a/gatorgrade/report_history.py
+++ b/gatorgrade/report_history.py
@@ -40,6 +40,12 @@ HISTORY_FILE_MODE_WRITE = "w"
 HISTORY_FILE_ENCODING = "utf-8"
 HISTORY_JSON_INDENT = 4
 HISTORY_TEMPORARY_SUFFIX = ".tmp"
+HISTORY_SKIP_UNREADABLE = "unreadable"
+HISTORY_SKIP_INVALID_JSON = "invalid_json"
+HISTORY_SKIP_NOT_OBJECT = "not_object"
+HISTORY_SKIP_UNSUPPORTED_SCHEMA = "unsupported_schema"
+HISTORY_SKIP_DIFFERENT_SCOPE = "different_scope"
+HISTORY_SKIP_MALFORMED_STRUCTURE = "malformed_structure"
 
 
 def get_report_history_directory() -> Path:
@@ -226,27 +232,55 @@ def save_report_history(  # noqa: PLR0913
     return destination
 
 
-def _load_history_file(  # noqa: PLR0911
+def _classify_history_file(  # noqa: PLR0911
     path: Path, scope: str
-) -> dict[str, Any] | None:
-    """Load one valid in-scope history file, or return None."""
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Classify one history file as valid payload or skip reason."""
     try:
         payload = json.loads(path.read_text(encoding=HISTORY_FILE_ENCODING))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None
+    except (OSError, UnicodeDecodeError):
+        return None, HISTORY_SKIP_UNREADABLE
+    except json.JSONDecodeError:
+        return None, HISTORY_SKIP_INVALID_JSON
     if not isinstance(payload, dict):
-        return None
+        return None, HISTORY_SKIP_NOT_OBJECT
     if payload.get(HISTORY_SCHEMA_KEY) != HISTORY_SCHEMA_VERSION:
-        return None
+        return None, HISTORY_SKIP_UNSUPPORTED_SCHEMA
     if payload.get(HISTORY_SCOPE_KEY) != scope:
         # report belongs to a different project scope — skip it
-        return None
+        return None, HISTORY_SKIP_DIFFERENT_SCOPE
     report = payload.get(HISTORY_REPORT_KEY)
     if not isinstance(report, dict):
-        return None
+        return None, HISTORY_SKIP_MALFORMED_STRUCTURE
     if not isinstance(report.get(CHECKS_KEY), list):
-        return None
-    return payload
+        return None, HISTORY_SKIP_MALFORMED_STRUCTURE
+    return payload, None
+
+
+def _load_history_file(path: Path, scope: str) -> dict[str, Any] | None:
+    """Load one valid in-scope history file, or return None."""
+    return _classify_history_file(path, scope)[0]
+
+
+def load_history_reports_with_diagnostics(
+    history_directory: Path,
+    scope: str,
+    maximum_reports: int | None = None,
+) -> tuple[list[dict[str, Any]], list[tuple[Path, str]]]:
+    """Load valid in-scope reports newest first, plus skip diagnostics."""
+    if maximum_reports is not None:
+        _validate_positive_limit(maximum_reports, "Maximum reports to load")
+    reports: list[dict[str, Any]] = []
+    diagnostics: list[tuple[Path, str]] = []
+    for path in reversed(_history_files(history_directory)):
+        payload, reason = _classify_history_file(path, scope)
+        if payload is not None:
+            reports.append(payload)
+            if maximum_reports is not None and len(reports) >= maximum_reports:
+                break
+        elif reason is not None:
+            diagnostics.append((path, reason))
+    return reports, diagnostics
 
 
 def load_history_reports(
@@ -255,15 +289,11 @@ def load_history_reports(
     maximum_reports: int | None = None,
 ) -> list[dict[str, Any]]:
     """Load valid in-scope reports, newest first."""
-    if maximum_reports is not None:
-        _validate_positive_limit(maximum_reports, "Maximum reports to load")
-    reports: list[dict[str, Any]] = []
-    for path in reversed(_history_files(history_directory)):
-        payload = _load_history_file(path, scope)
-        if payload is not None:
-            reports.append(payload)
-            if maximum_reports is not None and len(reports) >= maximum_reports:
-                break
+    reports, _ = load_history_reports_with_diagnostics(
+        history_directory,
+        scope,
+        maximum_reports=maximum_reports,
+    )
     return reports
 
 

--- a/tests/test_report_history.py
+++ b/tests/test_report_history.py
@@ -14,6 +14,17 @@ from gatorgrade.report_history import (
     CHECKS_KEY,
     HISTORY_FILE_PREFIX,
     HISTORY_FILE_SUFFIX,
+    HISTORY_REPORT_KEY,
+    HISTORY_SCHEMA_KEY,
+    HISTORY_SCHEMA_VERSION,
+    HISTORY_SCOPE_KEY,
+    HISTORY_SKIP_DIFFERENT_SCOPE,
+    HISTORY_SKIP_INVALID_JSON,
+    HISTORY_SKIP_MALFORMED_STRUCTURE,
+    HISTORY_SKIP_NOT_OBJECT,
+    HISTORY_SKIP_UNREADABLE,
+    HISTORY_SKIP_UNSUPPORTED_SCHEMA,
+    _classify_history_file,
     _history_filename,
     _history_files,
     _load_history_file,
@@ -27,6 +38,7 @@ from gatorgrade.report_history import (
     get_failed_check_ids,
     get_history_scope,
     load_history_reports,
+    load_history_reports_with_diagnostics,
     prune_report_history,
     save_report_history,
 )
@@ -34,6 +46,11 @@ from gatorgrade.report_history import (
 UTC = datetime.timezone.utc
 EXPECTED_RETAINED_REPORTS = 2
 EXPECTED_INSPECTED_REPORTS = 2
+EXPECTED_ONE_REPORT = 1
+EXPECTED_TWO_REPORTS = 2
+UNSUPPORTED_SCHEMA_VERSION = 999
+SCOPE_ONE = "project-one"
+SCOPE_TWO = "project-two"
 
 
 def _report(
@@ -384,3 +401,279 @@ def test_load_history_file_returns_none_for_non_list_checks(
     )
     result = _load_history_file(path, "s")
     assert result is None
+
+
+def _write_owned_history_file(
+    tmp_path: Path,
+    filename_stem: str,
+    payload: Any,
+) -> Path:
+    """Write one owned history filename with arbitrary JSON payload."""
+    destination = (
+        tmp_path / f"{HISTORY_FILE_PREFIX}{filename_stem}{HISTORY_FILE_SUFFIX}"
+    )
+    if isinstance(payload, str):
+        destination.write_text(payload, encoding="utf-8")
+    else:
+        destination.write_text(json.dumps(payload), encoding="utf-8")
+    return destination
+
+
+def test_classify_history_file_unreadable(tmp_path: Path) -> None:
+    """Unreadable paths classify as HISTORY_SKIP_UNREADABLE."""
+    path = tmp_path / "missing.json"
+    payload, reason = _classify_history_file(path, SCOPE_ONE)
+    assert payload is None
+    assert reason == HISTORY_SKIP_UNREADABLE
+
+
+def test_classify_history_file_invalid_json(tmp_path: Path) -> None:
+    """Invalid JSON classifies as HISTORY_SKIP_INVALID_JSON."""
+    path = _write_owned_history_file(tmp_path, "bad-json", "not valid json{")
+    payload, reason = _classify_history_file(path, SCOPE_ONE)
+    assert payload is None
+    assert reason == HISTORY_SKIP_INVALID_JSON
+
+
+def test_classify_history_file_not_object(tmp_path: Path) -> None:
+    """Non-object top-level JSON classifies as HISTORY_SKIP_NOT_OBJECT."""
+    path = _write_owned_history_file(tmp_path, "array", [])
+    payload, reason = _classify_history_file(path, SCOPE_ONE)
+    assert payload is None
+    assert reason == HISTORY_SKIP_NOT_OBJECT
+
+
+def test_classify_history_file_unsupported_schema(tmp_path: Path) -> None:
+    """Unsupported schema versions classify as HISTORY_SKIP_UNSUPPORTED_SCHEMA."""
+    path = _write_owned_history_file(
+        tmp_path,
+        "bad-schema",
+        {
+            HISTORY_SCHEMA_KEY: UNSUPPORTED_SCHEMA_VERSION,
+            HISTORY_SCOPE_KEY: SCOPE_ONE,
+            HISTORY_REPORT_KEY: {CHECKS_KEY: []},
+        },
+    )
+    payload, reason = _classify_history_file(path, SCOPE_ONE)
+    assert payload is None
+    assert reason == HISTORY_SKIP_UNSUPPORTED_SCHEMA
+
+
+def test_classify_history_file_different_scope(tmp_path: Path) -> None:
+    """Out-of-scope files classify as HISTORY_SKIP_DIFFERENT_SCOPE."""
+    path = _write_owned_history_file(
+        tmp_path,
+        "other-scope",
+        {
+            HISTORY_SCHEMA_KEY: HISTORY_SCHEMA_VERSION,
+            HISTORY_SCOPE_KEY: SCOPE_TWO,
+            HISTORY_REPORT_KEY: {CHECKS_KEY: []},
+        },
+    )
+    payload, reason = _classify_history_file(path, SCOPE_ONE)
+    assert payload is None
+    assert reason == HISTORY_SKIP_DIFFERENT_SCOPE
+
+
+def test_classify_history_file_malformed_non_dict_report(
+    tmp_path: Path,
+) -> None:
+    """Non-dict report classifies as HISTORY_SKIP_MALFORMED_STRUCTURE."""
+    path = _write_owned_history_file(
+        tmp_path,
+        "bad-report",
+        {
+            HISTORY_SCHEMA_KEY: HISTORY_SCHEMA_VERSION,
+            HISTORY_SCOPE_KEY: SCOPE_ONE,
+            HISTORY_REPORT_KEY: "not-a-dict",
+        },
+    )
+    payload, reason = _classify_history_file(path, SCOPE_ONE)
+    assert payload is None
+    assert reason == HISTORY_SKIP_MALFORMED_STRUCTURE
+
+
+def test_classify_history_file_malformed_non_list_checks(
+    tmp_path: Path,
+) -> None:
+    """Non-list checks classifies as HISTORY_SKIP_MALFORMED_STRUCTURE."""
+    path = _write_owned_history_file(
+        tmp_path,
+        "bad-checks",
+        {
+            HISTORY_SCHEMA_KEY: HISTORY_SCHEMA_VERSION,
+            HISTORY_SCOPE_KEY: SCOPE_ONE,
+            HISTORY_REPORT_KEY: {CHECKS_KEY: "not-a-list"},
+        },
+    )
+    payload, reason = _classify_history_file(path, SCOPE_ONE)
+    assert payload is None
+    assert reason == HISTORY_SKIP_MALFORMED_STRUCTURE
+
+
+def test_classify_history_file_success_returns_payload(
+    tmp_path: Path,
+) -> None:
+    """Valid in-scope files return the payload with no skip reason."""
+    path = save_report_history(
+        _report("ok", True),
+        scope=SCOPE_ONE,
+        history_directory=tmp_path,
+        current_time=datetime.datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    payload, reason = _classify_history_file(path, SCOPE_ONE)
+    assert reason is None
+    assert payload is not None
+    assert payload[HISTORY_SCOPE_KEY] == SCOPE_ONE
+
+
+def test_load_history_reports_with_diagnostics_newest_first(
+    tmp_path: Path,
+) -> None:
+    """Diagnostics loader returns valid reports newest first."""
+    save_report_history(
+        _report("older", False),
+        scope=SCOPE_ONE,
+        history_directory=tmp_path,
+        current_time=datetime.datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    save_report_history(
+        _report("newer", True),
+        scope=SCOPE_ONE,
+        history_directory=tmp_path,
+        current_time=datetime.datetime(2026, 1, 2, tzinfo=UTC),
+    )
+    reports, diagnostics = load_history_reports_with_diagnostics(
+        tmp_path,
+        SCOPE_ONE,
+    )
+    assert diagnostics == []
+    assert len(reports) == EXPECTED_TWO_REPORTS
+    assert [
+        report["report"]["checks"][0][CHECK_ID_KEY] for report in reports
+    ] == ["newer", "older"]
+
+
+def test_load_history_reports_with_diagnostics_maximum_counts_only_valid(
+    tmp_path: Path,
+) -> None:
+    """maximum_reports counts only valid payloads and still records skips."""
+    save_report_history(
+        _report("oldest-valid", False),
+        scope=SCOPE_ONE,
+        history_directory=tmp_path,
+        current_time=datetime.datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    _write_owned_history_file(tmp_path, "20260101T120000.000000Z-bad", "{")
+    save_report_history(
+        _report("middle-valid", True),
+        scope=SCOPE_ONE,
+        history_directory=tmp_path,
+        current_time=datetime.datetime(2026, 1, 2, tzinfo=UTC),
+    )
+    _write_owned_history_file(
+        tmp_path,
+        "20260102T120000.000000Z-scope",
+        {
+            HISTORY_SCHEMA_KEY: HISTORY_SCHEMA_VERSION,
+            HISTORY_SCOPE_KEY: SCOPE_TWO,
+            HISTORY_REPORT_KEY: {CHECKS_KEY: []},
+        },
+    )
+    save_report_history(
+        _report("newest-valid", True),
+        scope=SCOPE_ONE,
+        history_directory=tmp_path,
+        current_time=datetime.datetime(2026, 1, 3, tzinfo=UTC),
+    )
+    reports, diagnostics = load_history_reports_with_diagnostics(
+        tmp_path,
+        SCOPE_ONE,
+        maximum_reports=EXPECTED_TWO_REPORTS,
+    )
+    assert len(reports) == EXPECTED_TWO_REPORTS
+    assert [
+        report["report"]["checks"][0][CHECK_ID_KEY] for report in reports
+    ] == ["newest-valid", "middle-valid"]
+    reasons = {reason for _, reason in diagnostics}
+    assert (
+        HISTORY_SKIP_INVALID_JSON in reasons
+        or HISTORY_SKIP_DIFFERENT_SCOPE in reasons
+    )
+
+
+def test_load_history_reports_with_diagnostics_collects_skip_reasons(
+    tmp_path: Path,
+) -> None:
+    """Each skip reason is reported for owned history files."""
+    _write_owned_history_file(tmp_path, "invalid", "not-json")
+    _write_owned_history_file(tmp_path, "array", [])
+    _write_owned_history_file(
+        tmp_path,
+        "schema",
+        {
+            HISTORY_SCHEMA_KEY: UNSUPPORTED_SCHEMA_VERSION,
+            HISTORY_SCOPE_KEY: SCOPE_ONE,
+            HISTORY_REPORT_KEY: {CHECKS_KEY: []},
+        },
+    )
+    _write_owned_history_file(
+        tmp_path,
+        "scope",
+        {
+            HISTORY_SCHEMA_KEY: HISTORY_SCHEMA_VERSION,
+            HISTORY_SCOPE_KEY: SCOPE_TWO,
+            HISTORY_REPORT_KEY: {CHECKS_KEY: []},
+        },
+    )
+    _write_owned_history_file(
+        tmp_path,
+        "malformed",
+        {
+            HISTORY_SCHEMA_KEY: HISTORY_SCHEMA_VERSION,
+            HISTORY_SCOPE_KEY: SCOPE_ONE,
+            HISTORY_REPORT_KEY: {CHECKS_KEY: {}},
+        },
+    )
+    save_report_history(
+        _report("valid", True),
+        scope=SCOPE_ONE,
+        history_directory=tmp_path,
+        current_time=datetime.datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    reports, diagnostics = load_history_reports_with_diagnostics(
+        tmp_path,
+        SCOPE_ONE,
+    )
+    assert len(reports) == EXPECTED_ONE_REPORT
+    reasons = {reason for _, reason in diagnostics}
+    assert HISTORY_SKIP_INVALID_JSON in reasons
+    assert HISTORY_SKIP_NOT_OBJECT in reasons
+    assert HISTORY_SKIP_UNSUPPORTED_SCHEMA in reasons
+    assert HISTORY_SKIP_DIFFERENT_SCOPE in reasons
+    assert HISTORY_SKIP_MALFORMED_STRUCTURE in reasons
+
+
+def test_load_history_reports_delegates_to_diagnostics_loader(
+    tmp_path: Path,
+) -> None:
+    """load_history_reports remains newest-first after the refactor."""
+    save_report_history(
+        _report("first", False),
+        scope=SCOPE_ONE,
+        history_directory=tmp_path,
+        current_time=datetime.datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    save_report_history(
+        _report("second", True),
+        scope=SCOPE_ONE,
+        history_directory=tmp_path,
+        current_time=datetime.datetime(2026, 1, 2, tzinfo=UTC),
+    )
+    reports = load_history_reports(
+        tmp_path,
+        SCOPE_ONE,
+        maximum_reports=EXPECTED_ONE_REPORT,
+    )
+    assert len(reports) == EXPECTED_ONE_REPORT
+    assert reports[0]["report"]["checks"][0][CHECK_ID_KEY] == "second"


### PR DESCRIPTION
# feat: Report skip reasons when loading history reports

## Description

My contribution for the insights/analyze work. Adds a history-loading
API that returns valid report payloads plus structured skip diagnostics, so
later insights analysis can report why files were skipped.

Changes:
- Add `HISTORY_SKIP_*` constants for unreadable, invalid JSON, non-object,
unsupported schema, different scope, and malformed structure.
- Add `_classify_history_file` to classify each history file as a valid
payload or a skip reason.
- Keep `_load_history_file` behavior unchanged by returning
  `_classify_history_file(...)[0]`.
- Add `load_history_reports_with_diagnostics` (newest-first valid payloads;
  `maximum_reports` counts only valid reports).
- Make `load_history_reports` a thin wrapper over the diagnostics loader.
- Add unit tests for each skip reason, newest-first ordering, and
  maximum-report counting.

This PR does not add the insights CLI or aggregation module that part belongs to rest of the team.

## Linked Issues

Related to #215

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation

## Contributors

- `@ojharitesh`

## Reminder

- All GitHub Actions should be in a passing state before any pull request is merged.
- All PRs must be reviewed by at least one team member and one member of the
  Integration team (e.g., a senior member of the GatorGrader team).
- Any issues this PR closes are tagged in the description!